### PR TITLE
Add optimal solver in WCA metric

### DIFF
--- a/sq12phase/src/main/java/cs/sq12phase/FullCube.java
+++ b/sq12phase/src/main/java/cs/sq12phase/FullCube.java
@@ -46,17 +46,17 @@ public class FullCube implements Comparable<FullCube> {
         int edge = 0x01234567 << 1;
         int n_corner = 8, n_edge = 8;
         int rnd, m;
-        for (int i=0; i<24; i++) {
+        for (int i = 0; i < 24; i++) {
             if (((shape >> i) & 1) == 0) {//edge
                 rnd = r.nextInt(n_edge) << 2;
-                f.setPiece(23-i, (edge >> rnd) & 0xf);
+                f.setPiece(23 - i, (edge >> rnd) & 0xf);
                 m = (1 << rnd) - 1;
                 edge = (edge & m) + ((edge >> 4) & ~m);
                 --n_edge;
             } else {//corner
                 rnd = r.nextInt(n_corner) << 2;
-                f.setPiece(23-i, (corner >> rnd) & 0xf);
-                f.setPiece(22-i, (corner >> rnd) & 0xf);
+                f.setPiece(23 - i, (corner >> rnd) & 0xf);
+                f.setPiece(22 - i, (corner >> rnd) & 0xf);
                 m = (1 << rnd) - 1;
                 corner = (corner & m) + ((corner >> 4) & ~m);
                 --n_corner;
@@ -87,57 +87,57 @@ public class FullCube implements Comparable<FullCube> {
         if (move > 24) {
             move = 48 - move;
             int temp = ul;
-            ul = (ul>>move | ur<<(24-move)) & 0xffffff;
-            ur = (ur>>move | temp<<(24-move)) & 0xffffff;
+            ul = (ul >> move | ur << (24 - move)) & 0xffffff;
+            ur = (ur >> move | temp << (24 - move)) & 0xffffff;
         } else if (move > 0) {
             int temp = ul;
-            ul = (ul<<move | ur>>(24-move)) & 0xffffff;
-            ur = (ur<<move | temp>>(24-move)) & 0xffffff;
+            ul = (ul << move | ur >> (24 - move)) & 0xffffff;
+            ur = (ur << move | temp >> (24 - move)) & 0xffffff;
         } else if (move == 0) {
             int temp = ur;
             ur = dl;
             dl = temp;
-            ml = 1-ml;
+            ml = 1 - ml;
         } else if (move >= -24) {
             move = -move;
             int temp = dl;
-            dl = (dl<<move | dr>>(24-move)) & 0xffffff;
-            dr = (dr<<move | temp>>(24-move)) & 0xffffff;
+            dl = (dl << move | dr >> (24 - move)) & 0xffffff;
+            dr = (dr << move | temp >> (24 - move)) & 0xffffff;
         } else if (move < -24) {
             move = 48 + move;
             int temp = dl;
-            dl = (dl>>move | dr<<(24-move)) & 0xffffff;
-            dr = (dr>>move | temp<<(24-move)) & 0xffffff;
+            dl = (dl >> move | dr << (24 - move)) & 0xffffff;
+            dr = (dr >> move | temp << (24 - move)) & 0xffffff;
         }
     }
 
     private byte pieceAt(int idx) {
         int ret;
         if (idx < 6) {
-            ret = ul >> ((5-idx) << 2);
+            ret = ul >> ((5 - idx) << 2);
         } else if (idx < 12) {
-            ret = ur >> ((11-idx) << 2);
+            ret = ur >> ((11 - idx) << 2);
         } else if (idx < 18) {
-            ret = dl >> ((17-idx) << 2);
+            ret = dl >> ((17 - idx) << 2);
         } else {
-            ret = dr >> ((23-idx) << 2);
+            ret = dr >> ((23 - idx) << 2);
         }
         return (byte) (ret & 0x0f);
     }
 
     public void setPiece(int idx, int value) {
         if (idx < 6) {
-            ul &= ~(0xf << ((5-idx) << 2));
-            ul |= value << ((5-idx) << 2);
+            ul &= ~(0xf << ((5 - idx) << 2));
+            ul |= value << ((5 - idx) << 2);
         } else if (idx < 12) {
-            ur &= ~(0xf << ((11-idx) << 2));
-            ur |= value << ((11-idx) << 2);
+            ur &= ~(0xf << ((11 - idx) << 2));
+            ur |= value << ((11 - idx) << 2);
         } else if (idx < 18) {
-            dl &= ~(0xf << ((17-idx) << 2));
-            dl |= value << ((17-idx) << 2);
+            dl &= ~(0xf << ((17 - idx) << 2));
+            dl |= value << ((17 - idx) << 2);
         } else if (idx < 24) {
-            dr &= ~(0xf << ((23-idx) << 2));
-            dr |= value << ((23-idx) << 2);
+            dr &= ~(0xf << ((23 - idx) << 2));
+            dr |= value << ((23 - idx) << 2);
         } else {
             ml = value;
         }
@@ -148,16 +148,16 @@ public class FullCube implements Comparable<FullCube> {
     int getParity() {
         int cnt = 0;
         arr[0] = pieceAt(0);
-        for (int i=1; i<24; i++) {
+        for (int i = 1; i < 24; i++) {
             if (pieceAt(i) != arr[cnt]) {
                 arr[++cnt] = pieceAt(i);
             }
         }
         int p = 0;
-        for (int a=0; a<16; a++){
-            for(int b=a+1 ; b<16 ; b++){
+        for (int a = 0; a < 16; a++) {
+            for (int b = a + 1 ; b < 16 ; b++) {
                 if (arr[a] > arr[b]) {
-                    p^=1;
+                    p ^= 1;
                 }
             }
         }
@@ -168,20 +168,20 @@ public class FullCube implements Comparable<FullCube> {
         int urx = ur & 0x111111;
         urx |= urx >> 3;
         urx |= urx >> 6;
-        urx = (urx&0xf) | ((urx>>12)&0x30);
+        urx = (urx & 0xf) | ((urx >> 12) & 0x30);
         int ulx = ul & 0x111111;
         ulx |= ulx >> 3;
         ulx |= ulx >> 6;
-        ulx = (ulx&0xf) | ((ulx>>12)&0x30);
+        ulx = (ulx & 0xf) | ((ulx >> 12) & 0x30);
         int drx = dr & 0x111111;
         drx |= drx >> 3;
         drx |= drx >> 6;
-        drx = (drx&0xf) | ((drx>>12)&0x30);
+        drx = (drx & 0xf) | ((drx >> 12) & 0x30);
         int dlx = dl & 0x111111;
         dlx |= dlx >> 3;
         dlx |= dlx >> 6;
-        dlx = (dlx&0xf) | ((dlx>>12)&0x30);
-        return Shape.getShape2Idx(getParity()<<24 | ulx<<18 | urx<<12 | dlx<<6 | drx);
+        dlx = (dlx & 0xf) | ((dlx >> 12) & 0x30);
+        return Shape.getShape2Idx(getParity() << 24 | ulx << 18 | urx << 12 | dlx << 6 | drx);
     }
 
     void print() {
@@ -194,27 +194,27 @@ public class FullCube implements Comparable<FullCube> {
     byte[] prm = new byte[8];
 
     void getSquare(Square sq) {
-        for (int a=0;a<8;a++) {
-            prm[a] = (byte) (pieceAt(a*3+1)>>1);
+        for (int a = 0; a < 8; a++) {
+            prm[a] = (byte) (pieceAt(a * 3 + 1) >> 1);
         }
         //convert to number
         sq.cornperm = Square.get8Perm(prm);
 
         int a, b;
         //Strip top layer edges
-        sq.topEdgeFirst = pieceAt(0)==pieceAt(1);
+        sq.topEdgeFirst = pieceAt(0) == pieceAt(1);
         a = sq.topEdgeFirst ? 2 : 0;
-        for(b=0; b<4; a+=3, b++) {
-            prm[b]=(byte)(pieceAt(a)>>1);
+        for (b = 0; b < 4; a += 3, b++) {
+            prm[b] = (byte)(pieceAt(a) >> 1);
         }
 
-        sq.botEdgeFirst = pieceAt(12)==pieceAt(13);
+        sq.botEdgeFirst = pieceAt(12) == pieceAt(13);
         a = sq.botEdgeFirst ? 14 : 12;
 
-        for( ; b<8; a+=3, b++) {
-            prm[b]=(byte)(pieceAt(a)>>1);
+        for ( ; b < 8; a += 3, b++) {
+            prm[b] = (byte)(pieceAt(a) >> 1);
         }
-        sq.edgeperm=Square.get8Perm(prm);
+        sq.edgeperm = Square.get8Perm(prm);
         sq.ml = ml;
     }
 }

--- a/sq12phase/src/main/java/cs/sq12phase/Search.java
+++ b/sq12phase/src/main/java/cs/sq12phase/Search.java
@@ -3,18 +3,25 @@ package cs.sq12phase;
 
 public class Search {
 
+    static final int FACE_TURN_METRIC = 0;
+    static final int WCA_TURN_METRIC = 1;
+    static final int METRIC = WCA_TURN_METRIC; // only available for optimal solver
+
+    private static final int PRUN_INC = METRIC == WCA_TURN_METRIC ? 2 : 1;
+
     int[] move = new int[100];
     FullCube c = null;
     FullCube d = new FullCube("");
     int length1;
+    int movelen1;
     int maxlen2;
     String sol_string;
 
     static int getNParity(int idx, int n) {
         int p = 0;
-        for (int i=n-2; i>=0; i--) {
-            p ^= idx % (n-i);
-            idx /= (n-i);
+        for (int i = n - 2; i >= 0; i--) {
+            p ^= idx % (n - i);
+            idx /= (n - i);
         }
         return p & 1;
     }
@@ -28,7 +35,7 @@ public class Search {
         this.c = c;
         sol_string = null;
         int shape = c.getShapeIdx();
-        for (length1=Shape.ShapePrun[shape]; length1<100; length1++) {
+        for (length1 = Shape.ShapePrun[shape]; length1 < 100; length1++) {
             maxlen2 = Math.min(31 - length1, 17);
             if (phase1(shape, Shape.ShapePrun[shape], length1, 0, -1)) {
                 break;
@@ -41,26 +48,44 @@ public class Search {
         this.c = c;
         sol_string = null;
         int shape = c.getShapeIdx();
-        for (length1=Shape.ShapePrunOpt[shape]; length1<=maxl; length1++) {
-            if (phase1Opt(shape, Shape.ShapePrunOpt[shape], length1, 0, -1)) {
+        for (length1 = Shape.ShapePrunOpt[shape] * PRUN_INC; length1 <= maxl * PRUN_INC; length1 += PRUN_INC) {
+            if (phase1Opt(shape, Shape.ShapePrunOpt[shape], length1, 0, -1, 0)) {
                 break;
             }
         }
         return sol_string;
     }
 
+    static int count0xf(int val) {
+        val &= val >> 1;
+        val &= val >> 2;
+        return Integer.bitCount(val & 0x11111111);
+    }
 
-    boolean phase1Opt(int shape, int prunvalue, int maxl, int depth, int lm) {
-        if (maxl == 0) {
-            return isSolvedInPhase1();
+    boolean phase1Opt(int shape, int prunvalue, int maxl, int depth, int lm, int lastTurns) {
+        int i = count0xf((lastTurns ^ ~0x000000) & 0xff00ff)
+                - count0xf((lastTurns ^ ~0x666666) & 0xff00ff);
+        if (i < 0 || i == 0 && (lastTurns >> 20 & 0xf) >= 6) {
+            return false;
+        }
+
+        if (maxl / PRUN_INC == 0) {
+            movelen1 = depth;
+            if (isSolvedInPhase1()) {
+                return true;
+            }
+            if (maxl == 0) {
+                return false;
+            }
         }
         //try each possible move. First twist;
         if (lm != 0) {
             int shapex = Shape.TwistMove[shape];
-            int prunx = Shape.ShapePrunOpt[shapex];
-            if (prunx < maxl) {
+            int prun = Shape.ShapePrunOpt[shapex];
+            if (prun < maxl / PRUN_INC) {
                 move[depth] = 0;
-                if (phase1(shapex, prunx, maxl-1, depth+1, 0)) {
+                int next_maxl = (maxl / PRUN_INC - 1) * PRUN_INC;
+                if (phase1Opt(shapex, prun, next_maxl, depth + 1, 0, lastTurns << 8)) {
                     return true;
                 }
             }
@@ -68,21 +93,21 @@ public class Search {
 
         //Try top layer
         int shapex = shape;
-        if(lm <= 0){
+        if (lm <= 0) {
             int m = 0;
             while (true) {
                 m += Shape.TopMove[shapex];
                 shapex = m >> 4;
-                m &= 0x0f;
+                m &= 0xf;
                 if (m >= 12) {
                     break;
                 }
-                int prunx = Shape.ShapePrunOpt[shapex];
-                if (prunx > maxl) {
+                int prun = Shape.ShapePrunOpt[shapex];
+                if (prun * PRUN_INC > (maxl + PRUN_INC - 1)) {
                     break;
-                } else if (prunx < maxl) {
+                } else if (prun * PRUN_INC < (maxl + PRUN_INC - 1)) {
                     move[depth] = m;
-                    if (phase1(shapex, prunx, maxl-1, depth+1, 1)) {
+                    if (phase1Opt(shapex, prun, maxl - 1, depth + 1, 1, lastTurns | m << 4)) {
                         return true;
                     }
                 }
@@ -91,95 +116,91 @@ public class Search {
 
         shapex = shape;
         //Try bottom layer
-        if(lm <= 1){
+        if (lm <= 1) {
             int m = 0;
             while (true) {
                 m += Shape.BottomMove[shapex];
                 shapex = m >> 4;
-                m &= 0x0f;
-                if (m >= 6) {
+                m &= 0xf;
+                if (m >= 12) {
                     break;
                 }
-                int prunx = Shape.ShapePrunOpt[shapex];
-                if (prunx > maxl) {
+                int prun = Shape.ShapePrunOpt[shapex];
+                if (prun * PRUN_INC > (maxl + PRUN_INC - 1)) {
                     break;
-                } else if (prunx < maxl) {
+                } else if (prun * PRUN_INC < (maxl + PRUN_INC - 1)) {
                     move[depth] = -m;
-                    if (phase1(shapex, prunx, maxl-1, depth+1, 2)) {
+                    if (phase1Opt(shapex, prun, maxl - 1, depth + 1, 2, lastTurns | m)) {
                         return true;
                     }
                 }
             }
         }
-
         return false;
- 
     }
 
     boolean phase1(int shape, int prunvalue, int maxl, int depth, int lm) {
-
-        if (prunvalue==0 && maxl<4) {
-            return maxl==0 && init2();
+        if (prunvalue == 0 && maxl < 4) {
+            movelen1 = depth;
+            return maxl == 0 && init2();
         }
 
         //try each possible move. First twist;
         if (lm != 0) {
             int shapex = Shape.TwistMove[shape];
-            int prunx = Shape.ShapePrun[shapex];
-            if (prunx < maxl) {
+            int prun = Shape.ShapePrun[shapex];
+            if (prun < maxl) {
                 move[depth] = 0;
-                if (phase1(shapex, prunx, maxl-1, depth+1, 0)) {
+                if (phase1(shapex, prun, maxl - 1, depth + 1, 0)) {
                     return true;
                 }
             }
         }
-
         //Try top layer
-        int shapex = shape;
-        if(lm <= 0){
+        if (lm <= 0) {
             int m = 0;
+            int shapex = shape;
             while (true) {
                 m += Shape.TopMove[shapex];
                 shapex = m >> 4;
-                m &= 0x0f;
+                m &= 0xf;
                 if (m >= 12) {
                     break;
                 }
-                int prunx = Shape.ShapePrun[shapex];
-                if (prunx > maxl) {
+                int prun = Shape.ShapePrun[shapex];
+                if (prun > maxl) {
                     break;
-                } else if (prunx < maxl) {
+                } else if (prun < maxl) {
                     move[depth] = m;
-                    if (phase1(shapex, prunx, maxl-1, depth+1, 1)) {
+                    if (phase1(shapex, prun, maxl - 1, depth + 1, 1)) {
                         return true;
                     }
                 }
             }
         }
 
-        shapex = shape;
         //Try bottom layer
-        if(lm <= 1){
+        if (lm <= 1) {
             int m = 0;
+            int shapex = shape;
             while (true) {
                 m += Shape.BottomMove[shapex];
                 shapex = m >> 4;
-                m &= 0x0f;
+                m &= 0xf;
                 if (m >= 6) {
                     break;
                 }
-                int prunx = Shape.ShapePrun[shapex];
-                if (prunx > maxl) {
+                int prun = Shape.ShapePrun[shapex];
+                if (prun > maxl) {
                     break;
-                } else if (prunx < maxl) {
+                } else if (prun < maxl) {
                     move[depth] = -m;
-                    if (phase1(shapex, prunx, maxl-1, depth+1, 2)) {
+                    if (phase1(shapex, prun, maxl - 1, depth + 1, 2)) {
                         return true;
                     }
                 }
             }
         }
-
         return false;
     }
 
@@ -188,19 +209,20 @@ public class Search {
 
     boolean isSolvedInPhase1() {
         d.copy(c);
-        for (int i=0; i<length1; i++) {
+        for (int i = 0; i < movelen1; i++) {
             d.doMove(move[i]);
         }
-        boolean isSolved = d.ul == 0x011233 && d.ur == 455677 && d.dl == 0x998bba && d.dr == 0xddcffe && d.ml == 0;
+
+        boolean isSolved = d.ul == 0x011233 && d.ur == 0x455677 && d.dl == 0x998bba && d.dr == 0xddcffe && d.ml == 0;
         if (isSolved) {
-            sol_string = move2string(length1);
+            sol_string = move2string(movelen1);
         }
         return isSolved;
     }
 
     boolean init2() {
         d.copy(c);
-        for (int i=0; i<length1; i++) {
+        for (int i = 0; i < movelen1; i++) {
             d.doMove(move[i]);
         }
         assert Shape.ShapePrun[d.getShapeIdx()] == 0;
@@ -210,11 +232,11 @@ public class Search {
         int corner = sq.cornperm;
         int ml = sq.ml;
 
-        int prun = Math.max(Square.SquarePrun[sq.edgeperm<<1|ml], Square.SquarePrun[sq.cornperm<<1|ml]);
+        int prun = Math.max(Square.SquarePrun[sq.edgeperm << 1 | ml], Square.SquarePrun[sq.cornperm << 1 | ml]);
 
-        for (int i=prun; i<maxlen2; i++) {
-            if (phase2(edge, corner, sq.topEdgeFirst, sq.botEdgeFirst, ml, i, length1, 0)) {
-                sol_string = move2string(i + length1);
+        for (int i = prun; i < maxlen2; i++) {
+            if (phase2(edge, corner, sq.topEdgeFirst, sq.botEdgeFirst, ml, i, movelen1, 0)) {
+                sol_string = move2string(i + movelen1);
                 return true;
             }
         }
@@ -228,14 +250,14 @@ public class Search {
         //TODO whether to invert the solution or not should be set by params.
         StringBuffer s = new StringBuffer();
         int top = 0, bottom = 0;
-        for (int i=len-1; i>=0; i--) {
+        for (int i = len - 1; i >= 0; i--) {
             int val = move[i];
             if (val > 0) {
                 val = 12 - val;
-                top = (val > 6) ? (val-12) : val;
+                top = (val > 6) ? (val - 12) : val;
             } else if (val < 0) {
                 val = 12 + val;
-                bottom = (val > 6) ? (val-12) : val;
+                bottom = (val > 6) ? (val - 12) : val;
             } else {
                 if (top == 0 && bottom == 0) {
                     s.append(" / ");
@@ -255,73 +277,73 @@ public class Search {
 
     boolean phase2(int edge, int corner, boolean topEdgeFirst, boolean botEdgeFirst, int ml, int maxl, int depth, int lm) {
         if (maxl == 0 && !topEdgeFirst && botEdgeFirst) {
-            assert edge==0 && corner==0 && ml==0;
+            assert edge == 0 && corner == 0 && ml == 0;
             return true;
         }
 
         //try each possible move. First twist;
-        if(lm!=0 && topEdgeFirst == botEdgeFirst) {
+        if (lm != 0 && topEdgeFirst == botEdgeFirst) {
             int edgex = Square.TwistMove[edge];
             int cornerx = Square.TwistMove[corner];
 
-            if (Square.SquarePrun[edgex<<1|(1-ml)] < maxl && Square.SquarePrun[cornerx<<1|(1-ml)] < maxl) {
+            if (Square.SquarePrun[edgex << 1 | (1 - ml)] < maxl && Square.SquarePrun[cornerx << 1 | (1 - ml)] < maxl) {
                 move[depth] = 0;
-                if (phase2(edgex, cornerx, topEdgeFirst, botEdgeFirst, 1-ml, maxl-1, depth+1, 0)) {
+                if (phase2(edgex, cornerx, topEdgeFirst, botEdgeFirst, 1 - ml, maxl - 1, depth + 1, 0)) {
                     return true;
                 }
             }
         }
 
         //Try top layer
-        if (lm <= 0){
+        if (lm <= 0) {
             boolean topEdgeFirstx = !topEdgeFirst;
             int edgex = topEdgeFirstx ? Square.TopMove[edge] : edge;
             int cornerx = topEdgeFirstx ? corner : Square.TopMove[corner];
             int m = topEdgeFirstx ? 1 : 2;
-            int prun1 = Square.SquarePrun[edgex<<1|ml];
-            int prun2 = Square.SquarePrun[cornerx<<1|ml];
+            int prun1 = Square.SquarePrun[edgex << 1 | ml];
+            int prun2 = Square.SquarePrun[cornerx << 1 | ml];
             while (m < 12 && prun1 <= maxl && prun1 <= maxl) {
                 if (prun1 < maxl && prun2 < maxl) {
                     move[depth] = m;
-                    if (phase2(edgex, cornerx, topEdgeFirstx, botEdgeFirst, ml, maxl-1, depth+1, 1)) {
+                    if (phase2(edgex, cornerx, topEdgeFirstx, botEdgeFirst, ml, maxl - 1, depth + 1, 1)) {
                         return true;
                     }
                 }
                 topEdgeFirstx = !topEdgeFirstx;
                 if (topEdgeFirstx) {
                     edgex = Square.TopMove[edgex];
-                    prun1 = Square.SquarePrun[edgex<<1|ml];
+                    prun1 = Square.SquarePrun[edgex << 1 | ml];
                     m += 1;
                 } else {
                     cornerx = Square.TopMove[cornerx];
-                    prun2 = Square.SquarePrun[cornerx<<1|ml];
+                    prun2 = Square.SquarePrun[cornerx << 1 | ml];
                     m += 2;
                 }
             }
         }
 
-        if (lm <= 1){
+        if (lm <= 1) {
             boolean botEdgeFirstx = !botEdgeFirst;
             int edgex = botEdgeFirstx ? Square.BottomMove[edge] : edge;
             int cornerx = botEdgeFirstx ? corner : Square.BottomMove[corner];
             int m = botEdgeFirstx ? 1 : 2;
-            int prun1 = Square.SquarePrun[edgex<<1|ml];
-            int prun2 = Square.SquarePrun[cornerx<<1|ml];
+            int prun1 = Square.SquarePrun[edgex << 1 | ml];
+            int prun2 = Square.SquarePrun[cornerx << 1 | ml];
             while (m < (maxl > 6 ? 6 : 12) && prun1 <= maxl && prun1 <= maxl) {
                 if (prun1 < maxl && prun2 < maxl) {
                     move[depth] = -m;
-                    if (phase2(edgex, cornerx, topEdgeFirst, botEdgeFirstx, ml, maxl-1, depth+1, 2)) {
+                    if (phase2(edgex, cornerx, topEdgeFirst, botEdgeFirstx, ml, maxl - 1, depth + 1, 2)) {
                         return true;
                     }
                 }
                 botEdgeFirstx = !botEdgeFirstx;
                 if (botEdgeFirstx) {
                     edgex = Square.BottomMove[edgex];
-                    prun1 = Square.SquarePrun[edgex<<1|ml];
+                    prun1 = Square.SquarePrun[edgex << 1 | ml];
                     m += 1;
                 } else {
                     cornerx = Square.BottomMove[cornerx];
-                    prun2 = Square.SquarePrun[cornerx<<1|ml];
+                    prun2 = Square.SquarePrun[cornerx << 1 | ml];
                     m += 2;
                 }
             }

--- a/sq12phase/src/main/java/cs/sq12phase/SearchTest.java
+++ b/sq12phase/src/main/java/cs/sq12phase/SearchTest.java
@@ -1,33 +1,66 @@
 package cs.sq12phase;
 
 public class SearchTest {
+
+    static void OptimalSolverTest() {
+        long t = System.nanoTime();
+        Search s = new Search();
+        java.util.Random gen = new java.util.Random(42L);
+        int targetLength = 11;
+        int scrambleLength = 11;
+        for (int x = 0; x < 1000; x++) {
+            FullCube fc = new FullCube();
+            int shape = fc.getShapeIdx();
+            int lm = -1;
+            for (int i = 0; i < scrambleLength; i++) {
+                int move;
+                do {
+                    move = gen.nextInt(3);
+                } while (move == lm || move == 1 && lm == 2);
+                lm = move;
+                if (move == 0) {
+                    s.move[i] = 0;
+                    fc.doMove(0);
+                } else if (move == 1) {
+                    int m = Shape.TopMove[shape] & 0xf;
+                    s.move[i] = m;
+                    fc.doMove(m);
+                } else {
+                    int m = Shape.BottomMove[shape] & 0xf;
+                    s.move[i] = -m;
+                    fc.doMove(-m);
+                }
+                shape = fc.getShapeIdx();
+            }
+            System.out.println("Scramble: " + s.move2string(scrambleLength));
+            String sol = s.solutionOpt(fc, targetLength);
+            System.out.println("Solution: " + sol);
+            System.out.println(
+                String.format("%.2fms\n",
+                              (System.nanoTime() - t) / 1000000.0 / (x + 1)));
+        }
+    }
+
+    static void RandomSolvingTest() {
+        long t = System.nanoTime();
+        Search s = new Search();
+        java.util.Random gen = new java.util.Random(42L);
+        for (int x = 0; x < 1000; x++) {
+            String sol = s.solution(FullCube.randomCube(gen));
+            System.out.println(sol);
+            System.out.println(
+                String.format("%.2fms",
+                              (System.nanoTime() - t) / 1000000.0 / (x + 1)));
+        }
+    }
+
     public static void main(String[] args) {
         long t = System.nanoTime();
 
-//      FullCube f;// = new FullCube("");
-//      System.out.println(f.getParity());
-//      System.out.println(f.getShapeIdx());
-//      System.out.println(Shape.ShapePrun[f.getShapeIdx()]);
-//      int a = Square.SquarePrun[0];
-//      Random gen = new Random(1000L);
         new Search().solution(new FullCube(""));
-        System.out.println((System.nanoTime()-t)/1e9 + " seconds to initialize");
+        System.out.println((System.nanoTime() - t) / 1e9 + " seconds to initialize");
 
-
-        t = System.nanoTime();
-        for (int x=0; x<1000; x++) {
-
-    //      System.out.println(m);
-    //      System.out.println(Integer.toBinaryString(Shape.ShapeIdx[shape>>1]));
-    //      System.out.println(Integer.toBinaryString(Shape.ShapeIdx[f.getShapeIdx()>>1]));
-//          assert f.getShapeIdx() == shape;
-//          f.print();
-            Search s = new Search();
-//          s.solution(FullCube.randomCube());
-            System.out.println(s.solution(FullCube.randomCube()));
-            System.out.println((System.nanoTime()-t)/1e9/(x+1));
-//          t = System.nanoTime();
-        }
-
+        RandomSolvingTest();
+        OptimalSolverTest();
     }
 }

--- a/sq12phase/src/main/java/cs/sq12phase/Shape.java
+++ b/sq12phase/src/main/java/cs/sq12phase/Shape.java
@@ -6,29 +6,30 @@ class Shape {
 
     //1 = corner, 0 = edge.
     static int[] halflayer = {0x00, 0x03, 0x06, 0x0c, 0x0f, 0x18, 0x1b, 0x1e,
-        0x30, 0x33, 0x36, 0x3c, 0x3f};
+                              0x30, 0x33, 0x36, 0x3c, 0x3f
+                             };
 
     static int[] ShapeIdx = new int[3678];
-    static int[] ShapePrun = new int[3768 * 2];
-    static int[] ShapePrunOpt = new int[3768 * 2];
+    static int[] ShapePrun = new int[3678 * 2];
+    static int[] ShapePrunOpt = new int[3678 * 2];
 
     static int[] TopMove = new int[3678 * 2];
     static int[] BottomMove = new int[3678 * 2];
     static int[] TwistMove = new int[3678 * 2];
 
-    private Shape(){}
+    private Shape() {}
 
     int top;
     int bottom;
     int parity;
 
     static int getShape2Idx(int shp) {
-        int ret = Arrays.binarySearch(ShapeIdx, shp & 0xffffff)<<1 | shp>>24;
+        int ret = Arrays.binarySearch(ShapeIdx, shp & 0xffffff) << 1 | shp >> 24;
         return ret;
     }
 
     int getIdx() {
-        int ret = Arrays.binarySearch(ShapeIdx, top<<12|bottom)<<1|parity;
+        int ret = Arrays.binarySearch(ShapeIdx, top << 12 | bottom) << 1 | parity;
         return ret;
     }
 
@@ -52,7 +53,7 @@ class Shape {
             }
             moveParity = 1 - moveParity;
         } while ((Integer.bitCount(top & 0x3f) & 1) != 0);
-        if ((Integer.bitCount(top)&2)==0) {
+        if ((Integer.bitCount(top) & 2) == 0) {
             parity ^= moveParity;
         }
         return move;
@@ -63,15 +64,15 @@ class Shape {
         int moveParity = 0;
         do {
             if ((bottom & 0x800) == 0) {
-                move +=1;
+                move += 1;
                 bottom = bottom << 1;
             } else {
-                move +=2;
+                move += 2;
                 bottom = (bottom << 2) ^ 0x3003;
             }
             moveParity = 1 - moveParity;
         } while ((Integer.bitCount(bottom & 0x3f) & 1) != 0);
-        if ((Integer.bitCount(bottom)&2)==0) {
+        if ((Integer.bitCount(bottom) & 2) == 0) {
             parity ^= moveParity;
         }
         return move;
@@ -80,8 +81,8 @@ class Shape {
     void twistMove() {
         int temp = top & 0x3f;
         int p1 = Integer.bitCount(temp);
-        int p3 = Integer.bitCount(bottom&0xfc0);
-        parity ^= 1 & ((p1&p3)>>1);
+        int p3 = Integer.bitCount(bottom & 0xfc0);
+        parity ^= 1 & ((p1 & p3) >> 1);
 
         top = (top & 0xfc0) | ((bottom >> 6) & 0x3f);
         bottom = (bottom & 0x3f) | temp << 6;
@@ -89,24 +90,86 @@ class Shape {
 
     static boolean inited = false;
 
+    static void initPruning(int[] Prun, int done, int metric) {
+        int done0 = 0;
+        int depth = -1;
+        while (done != done0) {
+            done0 = done;
+            ++depth;
+            System.out.println(String.format("%2d%6d", depth, done));
+            for (int i = 0; i < 3678 * 2; i++) {
+                if (Prun[i] != depth) {
+                    continue;
+                }
+                // try twist
+                {
+                    int idx = TwistMove[i];
+                    if (Prun[idx] == -1) {
+                        ++done;
+                        Prun[idx] = depth + 1;
+                    }
+                }
+
+                if (metric == Search.FACE_TURN_METRIC) {
+                    // try top move
+                    for (int m = 0, inc = 0, idx = i; m != 12; m += inc) {
+                        idx = TopMove[idx];
+                        inc = idx & 0xf;
+                        idx >>= 4;
+                        if (Prun[idx] == -1) {
+                            ++done;
+                            Prun[idx] = depth + 1;
+                        }
+                    }
+                    // try bottom
+                    for (int m = 0, inc = 0, idx = i; m != 12; m += inc) {
+                        idx = BottomMove[idx];
+                        inc = idx & 0xf;
+                        idx >>= 4;
+                        if (Prun[idx] == -1) {
+                            ++done;
+                            Prun[idx] = depth + 1;
+                        }
+                    }
+                } else if (metric == Search.WCA_TURN_METRIC) {
+                    // try top/bottom move
+                    for (int m = 0, inc = 0, idx = i; m != 12; m += inc) {
+                        idx = TopMove[idx];
+                        inc = idx & 0xf;
+                        idx >>= 4;
+                        for (int m2 = 0, inc2 = 0, idx2 = idx; m2 != 12; m2 += inc2) {
+                            idx2 = BottomMove[idx2];
+                            inc2 = idx2 & 0xf;
+                            idx2 >>= 4;
+                            if (Prun[idx2] == -1) {
+                                ++done;
+                                Prun[idx2] = depth + 1;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     static void init() {
         if (inited) {
             return;
         }
         int count = 0;
-        for (int i=0; i<13*13*13*13; i++) {
+        for (int i = 0; i < 13 * 13 * 13 * 13; i++) {
             int dr = halflayer[i % 13];
             int dl = halflayer[i / 13 % 13];
             int ur = halflayer[i / 13 / 13 % 13];
             int ul = halflayer[i / 13 / 13 / 13];
-            int value = ul<<18|ur<<12|dl<<6|dr;
+            int value = ul << 18 | ur << 12 | dl << 6 | dr;
             if (Integer.bitCount(value) == 16) {
                 ShapeIdx[count++] = value;
             }
         }
         System.out.println(count);
         Shape s = new Shape();
-        for (int i=0; i<3678*2; i++) {
+        for (int i = 0; i < 3678 * 2; i++) {
             s.setIdx(i);
             TopMove[i] = s.topMove();
             TopMove[i] |= s.getIdx() << 4;
@@ -117,108 +180,18 @@ class Shape {
             s.twistMove();
             TwistMove[i] = s.getIdx();
         }
-        for (int i=0; i<3768*2; i++) {
+        for (int i = 0; i < 3678 * 2; i++) {
             ShapePrun[i] = -1;
             ShapePrunOpt[i] = -1;
         }
 
-        //0 110110110110 011011011011
-        //1 110110110110 110110110110
-        //1 011011011011 011011011011
-        //0 011011011011 110110110110
-        ShapePrun[getShape2Idx(0x0db66db)] = 0;
-        ShapePrun[getShape2Idx(0x1db6db6)] = 0;
-        ShapePrun[getShape2Idx(0x16db6db)] = 0;
-        ShapePrun[getShape2Idx(0x06dbdb6)] = 0;
+        ShapePrun[getShape2Idx(0x0db66db)] = 0; //0 110110110110 011011011011
+        ShapePrun[getShape2Idx(0x1db6db6)] = 0; //1 110110110110 110110110110
+        ShapePrun[getShape2Idx(0x16db6db)] = 0; //1 011011011011 011011011011
+        ShapePrun[getShape2Idx(0x06dbdb6)] = 0; //0 011011011011 110110110110
         ShapePrunOpt[new FullCube().getShapeIdx()] = 0;
-        int done = 4;
-        int done0 = 0;
-        int depth = -1;
-        while (done != done0) {
-            done0 = done;
-            ++depth;
-            System.out.println(done);
-            for (int i=0; i<3768*2; i++) {
-                if (ShapePrun[i] == depth) {
-                    // try top
-                    int m = 0;
-                    int idx = i;
-                    do {
-                        idx = TopMove[idx];
-                        m += idx & 0xf;
-                        idx >>= 4;
-                        if (ShapePrun[idx] == -1) {
-                            ++done;
-                            ShapePrun[idx] = depth + 1;
-                        }
-                    } while (m != 12);
-
-                    // try bottom
-                    m = 0;
-                    idx = i;
-                    do {
-                        idx = BottomMove[idx];
-                        m += idx & 0xf;
-                        idx >>= 4;
-                        if (ShapePrun[idx] == -1) {
-                            ++done;
-                            ShapePrun[idx] = depth + 1;
-                        }
-                    } while (m != 12);
-
-                    // try twist
-                    idx = TwistMove[i];
-                    if (ShapePrun[idx] == -1) {
-                        ++done;
-                        ShapePrun[idx] = depth + 1;
-                    }
-                }
-            }
-        }
-        done = 1;
-        done0 = 0;
-        depth = -1;
-        while (done != done0) {
-            done0 = done;
-            ++depth;
-            System.out.println(done);
-            for (int i=0; i<3768*2; i++) {
-                if (ShapePrunOpt[i] == depth) {
-                    // try top
-                    int m = 0;
-                    int idx = i;
-                    do {
-                        idx = TopMove[idx];
-                        m += idx & 0xf;
-                        idx >>= 4;
-                        if (ShapePrunOpt[idx] == -1) {
-                            ++done;
-                            ShapePrunOpt[idx] = depth + 1;
-                        }
-                    } while (m != 12);
-
-                    // try bottom
-                    m = 0;
-                    idx = i;
-                    do {
-                        idx = BottomMove[idx];
-                        m += idx & 0xf;
-                        idx >>= 4;
-                        if (ShapePrunOpt[idx] == -1) {
-                            ++done;
-                            ShapePrunOpt[idx] = depth + 1;
-                        }
-                    } while (m != 12);
-
-                    // try twist
-                    idx = TwistMove[i];
-                    if (ShapePrunOpt[idx] == -1) {
-                        ++done;
-                        ShapePrunOpt[idx] = depth + 1;
-                    }
-                }
-            }
-        }
+        initPruning(ShapePrun, 4, Search.FACE_TURN_METRIC);
+        initPruning(ShapePrunOpt, 1, Search.METRIC);
         inited = true;
     }
 

--- a/sq12phase/src/main/java/cs/sq12phase/Square.java
+++ b/sq12phase/src/main/java/cs/sq12phase/Square.java
@@ -8,7 +8,6 @@ class Square {
     int ml;         //shape of middle layer (+/-1, or 0 if ignored)
 
     static byte[] SquarePrun = new byte[40320 * 2];         //pruning table; #twists to solve corner|edge permutation
-
     static char[] TwistMove = new char[40320];          //transition table for twists
     static char[] TopMove = new char[40320];            //transition table for top layer turns
     static char[] BottomMove = new char[40320];         //transition table for bottom layer turns
@@ -17,10 +16,10 @@ class Square {
 
     static void set8Perm(byte[] arr, int idx) {
         int val = 0x76543210;
-        for (int i=0; i<7; i++) {
-            int p = fact[7-i];
+        for (int i = 0; i < 7; i++) {
+            int p = fact[7 - i];
             int v = idx / p;
-            idx -= v*p;
+            idx -= v * p;
             v <<= 2;
             arr[i] = (byte) ((val >> v) & 07);
             int m = (1 << v) - 1;
@@ -32,7 +31,7 @@ class Square {
     static char get8Perm(byte[] arr) {
         int idx = 0;
         int val = 0x76543210;
-        for (int i=0; i<7; i++) {
+        for (int i = 0; i < 7; i++) {
             int v = arr[i] << 2;
             idx = (8 - i) * idx + ((val >> v) & 07);
             val -= 0x11111110 << v;
@@ -44,9 +43,9 @@ class Square {
 
     static int get8Comb(byte[] arr) {
         int idx = 0, r = 4;
-        for (int i=0; i<8; i++) {
+        for (int i = 0; i < 8; i++) {
             if (arr[i] >= 4) {
-                idx += Cnk[7-i][r--];
+                idx += Cnk[7 - i][r--];
             }
         }
         return idx;
@@ -58,36 +57,36 @@ class Square {
         if (inited) {
             return;
         }
-        for (int i=0; i<12; i++) {
+        for (int i = 0; i < 12; i++) {
             Cnk[i][0] = 1;
             Cnk[i][i] = 1;
-            for (int j=1; j<i; j++) {
-                Cnk[i][j] = Cnk[i-1][j-1] + Cnk[i-1][j];
+            for (int j = 1; j < i; j++) {
+                Cnk[i][j] = Cnk[i - 1][j - 1] + Cnk[i - 1][j];
             }
         }
         byte[] pos = new byte[8];
         byte temp;
 
-        for(int i=0;i<40320;i++){
+        for (int i = 0; i < 40320; i++) {
             //twist
             set8Perm(pos, i);
 
-            temp=pos[2];pos[2]=pos[4];pos[4]=temp;
-            temp=pos[3];pos[3]=pos[5];pos[5]=temp;
-            TwistMove[i]=get8Perm(pos);
+            temp = pos[2]; pos[2] = pos[4]; pos[4] = temp;
+            temp = pos[3]; pos[3] = pos[5]; pos[5] = temp;
+            TwistMove[i] = get8Perm(pos);
 
             //top layer turn
             set8Perm(pos, i);
-            temp=pos[0]; pos[0]=pos[1]; pos[1]=pos[2]; pos[2]=pos[3]; pos[3]=temp;
-            TopMove[i]=get8Perm(pos);
+            temp = pos[0]; pos[0] = pos[1]; pos[1] = pos[2]; pos[2] = pos[3]; pos[3] = temp;
+            TopMove[i] = get8Perm(pos);
 
             //bottom layer turn
             set8Perm(pos, i);
-            temp=pos[4]; pos[4]=pos[5]; pos[5]=pos[6]; pos[6]=pos[7]; pos[7]=temp;
-            BottomMove[i]=get8Perm(pos);
+            temp = pos[4]; pos[4] = pos[5]; pos[5] = pos[6]; pos[6] = pos[7]; pos[7] = temp;
+            BottomMove[i] = get8Perm(pos);
         }
 
-        for (int i=0; i<40320*2; i++) {
+        for (int i = 0; i < 40320 * 2; i++) {
             SquarePrun[i] = -1;
         }
         SquarePrun[0] = 0;
@@ -99,53 +98,48 @@ class Square {
             int check = inv ? depth : -1;
             ++depth;
             OUT:
-            for (int i=0; i<40320*2; i++) {
-                if (SquarePrun[i] == find) {
-                    int idx = i >> 1;
-                    int ml = i & 1;
+            for (int i = 0; i < 40320 * 2; i++) {
+                if (SquarePrun[i] != find) {
+                    continue;
+                }
+                int perm = i >> 1;
+                int ml = i & 1;
 
-                    //try twist
-                    int idxx = TwistMove[idx]<<1 | (1-ml);
-                    if(SquarePrun[idxx] == check) {
+                //try twist
+                int idx = TwistMove[perm] << 1 | (1 - ml);
+                if (SquarePrun[idx] == check) {
+                    ++done;
+                    SquarePrun[inv ? i : idx] = (byte) (depth);
+                    if (inv) {
+                        continue OUT;
+                    }
+                }
+                //try turning top layer
+                for (int m = 0; m < 4; m++) {
+                    perm = TopMove[perm];
+                    idx = perm << 1 | ml;
+                    if (SquarePrun[idx] == check) {
                         ++done;
-                        SquarePrun[inv ? i : idxx] = (byte) (depth);
+                        SquarePrun[inv ? i : idx] = (byte) (depth);
                         if (inv) {
                             continue OUT;
                         }
                     }
-
-                    //try turning top layer
-                    idxx = idx;
-                    for(int m=0; m<4; m++) {
-                        idxx = TopMove[idxx];
-                        if(SquarePrun[idxx<<1|ml] == check){
-                            ++done;
-                            SquarePrun[inv ? i : (idxx<<1|ml)] = (byte) (depth);
-                            if (inv) {
-                                continue OUT;
-                            }
+                }
+                //try turning bottom layer
+                for (int m = 0; m < 4; m++) {
+                    perm = BottomMove[perm];
+                    if (SquarePrun[perm << 1 | ml] == check) {
+                        ++done;
+                        SquarePrun[inv ? i : (perm << 1 | ml)] = (byte) (depth);
+                        if (inv) {
+                            continue OUT;
                         }
                     }
-                    assert idxx == idx;
-                    //try turning bottom layer
-                    for(int m=0; m<4; m++) {
-                        idxx = BottomMove[idxx];
-                        if(SquarePrun[idxx<<1|ml] == check){
-                            ++done;
-                            SquarePrun[inv ? i : (idxx<<1|ml)] = (byte) (depth);
-                            if (inv) {
-                                continue OUT;
-                            }
-                        }
-                    }
-
                 }
             }
-            System.out.print(depth);
-            System.out.print('\t');
-            System.out.println(done);
+            System.out.println(String.format("%2d%6d", depth, done));
         }
         inited = true;
     }
-
 }


### PR DESCRIPTION
Since (x, y) is counted as a single move in WCA metric, the number of states that can be solved in 11 moves is much larger than that in face turn metric. Similarly, the search space is also much larger than that in face turn metric at specific move limit.

On my laptop, the average solving time spent for checking 11-move solvability is about 10ms for a random state. However, for specific states (e.g. 15-move scrambled state), it might take several seconds to do the verification.