### PR TITLE
Fix threephase initStatus after reading file from disk

### DIFF
--- a/threephase/src/main/java/cs/threephase/Tools.java
+++ b/threephase/src/main/java/cs/threephase/Tools.java
@@ -61,6 +61,7 @@ public class Tools {
 		Edge3.initMvrot();
 		Edge3.initRaw2Sym();
 		read(Edge3.eprun, in);
+		Edge3.done = Edge3.N_EPRUN;
 
 		logger.info("OK");
 


### PR DESCRIPTION
See title. This is essentially replicating the condition from https://github.com/suushiemaniac/tnoodle-lib/blob/64eae76555321ac6801f817c4e9deb3cf8815c9a/threephase/src/main/java/cs/threephase/Edge3.java#L166