### PR TITLE
Add POC for "layered randomization" big cube scrambles

### DIFF
--- a/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/LayeredRandomizationCubePuzzle.java
+++ b/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/LayeredRandomizationCubePuzzle.java
@@ -64,22 +64,7 @@ public class LayeredRandomizationCubePuzzle extends CubePuzzle {
             }
         }
 
-        // we take a "classic" big cube scramble sequence as reference
-        // because there is currently no API to generate N random moves directly
-        // (and I am too lazy to write one if we already have something that comes close)
-        PuzzleStateAndGenerator randomMovesPsag = super.generateRandomMoves(r);
-        String[] randomMoves = AlgorithmBuilder.splitAlgorithm(randomMovesPsag.generator);
-
-        int remainingLength = this.getRandomMoveCount() - ab.getTotalCost();
-
-        for (int i = 0; i < remainingLength; i++) {
-            try {
-                ab.appendMove(randomMoves[i]);
-            } catch (InvalidMoveException e) {
-                l.log(Level.SEVERE, "", e);
-                throw new RuntimeException(e);
-            }
-        }
+        fillWithRandomMoves(ab, r, getRandomMoveCount());
 
         return ab.getStateAndGenerator();
     }

--- a/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/LayeredRandomizationCubePuzzle.java
+++ b/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/LayeredRandomizationCubePuzzle.java
@@ -7,7 +7,7 @@ import org.worldcubeassociation.tnoodle.scrambles.PuzzleStateAndGenerator;
 import java.util.Random;
 import java.util.logging.Level;
 
-public class OuterRandomCubePuzzle extends CubePuzzle {
+public class LayeredRandomizationCubePuzzle extends CubePuzzle {
     private final ThreadLocal<ThreeByThreeCubePuzzle> threeScrambler;
     private final ThreadLocal<TwoByTwoCubePuzzle> twoScrambler;
 
@@ -17,7 +17,7 @@ public class OuterRandomCubePuzzle extends CubePuzzle {
     // to centers will be scrambled.
     private static final int EXCLUDE_OUTER_LAYERS = 1;
 
-    public OuterRandomCubePuzzle(int size) {
+    public LayeredRandomizationCubePuzzle(int size) {
         super(size);
 
         this.threeScrambler = ThreadLocal.withInitial(ThreeByThreeCubePuzzle::new);
@@ -26,12 +26,12 @@ public class OuterRandomCubePuzzle extends CubePuzzle {
 
     @Override
     public String getLongName() {
-        return super.getLongName() + " (outer-random)";
+        return super.getLongName() + " (layered randomization)";
     }
 
     @Override
     public String getShortName() {
-        return super.getShortName() + "or";
+        return super.getShortName() + "lrand";
     }
 
     @Override

--- a/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/OuterRandomCubePuzzle.java
+++ b/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/OuterRandomCubePuzzle.java
@@ -1,0 +1,117 @@
+package org.worldcubeassociation.tnoodle.puzzle;
+
+import org.worldcubeassociation.tnoodle.scrambles.AlgorithmBuilder;
+import org.worldcubeassociation.tnoodle.scrambles.InvalidMoveException;
+import org.worldcubeassociation.tnoodle.scrambles.PuzzleStateAndGenerator;
+
+import java.util.Random;
+import java.util.logging.Level;
+
+public class OuterRandomCubePuzzle extends CubePuzzle {
+    private final ThreadLocal<ThreeByThreeCubePuzzle> threeScrambler;
+    private final ThreadLocal<TwoByTwoCubePuzzle> twoScrambler;
+
+    // number of outer layers to exclude from the "thickness" scrambling process.
+    // The current setting means that the outermost layer (the "reduction phase")
+    // won't receive an additional 3x3 scramble and only the layers that are relevant
+    // to centers will be scrambled.
+    private static final int EXCLUDE_OUTER_LAYERS = 1;
+
+    public OuterRandomCubePuzzle(int size) {
+        super(size);
+
+        this.threeScrambler = ThreadLocal.withInitial(ThreeByThreeCubePuzzle::new);
+        this.twoScrambler = ThreadLocal.withInitial(TwoByTwoCubePuzzle::new);
+    }
+
+    @Override
+    public String getLongName() {
+        return super.getLongName() + " (outer-random)";
+    }
+
+    @Override
+    public String getShortName() {
+        return super.getShortName() + "or";
+    }
+
+    @Override
+    public double getInitializationStatus() {
+        double threeInit = this.threeScrambler.get().getInitializationStatus();
+        double twoInit = this.twoScrambler.get().getInitializationStatus();
+
+        return (threeInit + twoInit) / 2;
+    }
+
+    @Override
+    public PuzzleStateAndGenerator generateRandomMoves(Random r) {
+        AlgorithmBuilder ab = new AlgorithmBuilder(this, AlgorithmBuilder.MergingMode.CANONICALIZE_MOVES);
+
+        int thickLayers = this.size / 2;
+
+        for (int thickness = EXCLUDE_OUTER_LAYERS; thickness < thickLayers; thickness++) {
+            // need to pass thickness here to determine if we need 3x3 scr
+            // or 2x2 scr (on the innermost layer of even-numbered NxN)
+            String rawScramble = generateOuterScramble(thickness, r);
+
+            // transform the entire scramble to wide grips. This performs absolutely no sanity checks at the moment!
+            String morphedScramble = transformScrambleToThickness(rawScramble, thickness);
+
+            try {
+                ab.appendAlgorithm(morphedScramble);
+            } catch (InvalidMoveException e) {
+                l.log(Level.SEVERE, "", e);
+                throw new RuntimeException(e);
+            }
+        }
+
+        // we take a "classic" big cube scramble sequence as reference
+        // because there is currently no API to generate N random moves directly
+        // (and I am too lazy to write one if we already have something that comes close)
+        PuzzleStateAndGenerator randomMovesPsag = super.generateRandomMoves(r);
+        String[] randomMoves = AlgorithmBuilder.splitAlgorithm(randomMovesPsag.generator);
+
+        int remainingLength = this.getRandomMoveCount() - ab.getTotalCost();
+
+        for (int i = 0; i < remainingLength; i++) {
+            try {
+                ab.appendMove(randomMoves[i]);
+            } catch (InvalidMoveException e) {
+                l.log(Level.SEVERE, "", e);
+                throw new RuntimeException(e);
+            }
+        }
+
+        return ab.getStateAndGenerator();
+    }
+
+    private String generateOuterScramble(int thickness, Random r) {
+        if (this.size % 2 == 0 && thickness == (this.size / 2) - 1) {
+            return this.twoScrambler.get().generateWcaScramble(r);
+        }
+
+        return this.threeScrambler.get().generateWcaScramble(r);
+    }
+
+    private String transformScrambleToThickness(String rawScramble, int thickness) {
+        String[] rawMoves = AlgorithmBuilder.splitAlgorithm(rawScramble);
+        StringBuilder transformedMoves = new StringBuilder();
+
+        // This parsing method is very hacky in that it silently assumes it only ever handles
+        // 2x2 and 3x3 scrambles. Concepts like "Fw" (w at the end) or even "3Fw" (number at the front)
+        // are absolutely not accounted for because we don't need them for the current generators.
+        for (String rawMove : rawMoves) {
+            String rawFace = String.valueOf(rawMove.charAt(0));
+            Face f = Face.valueOf(rawFace);
+
+            String dirModifier = rawMove.substring(1).replace('\'', '3');
+            int dir = dirModifier.length() == 0 ? 1 : Integer.parseInt(dirModifier);
+
+            CubeMove thickMove = new CubeMove(f, dir, thickness);
+
+            transformedMoves.append(thickMove);
+            transformedMoves.append(" ");
+        }
+
+        return transformedMoves.toString().trim();
+    }
+}

--- a/scrambles/src/main/java/org/worldcubeassociation/tnoodle/scrambles/Puzzle.java
+++ b/scrambles/src/main/java/org/worldcubeassociation/tnoodle/scrambles/Puzzle.java
@@ -37,7 +37,7 @@ import static java.lang.Math.ceil;
  */
 @ExportClosure
 public abstract class Puzzle implements Exportable {
-    private static final Logger l = Logger.getLogger(Puzzle.class.getName());
+    protected static final Logger l = Logger.getLogger(Puzzle.class.getName());
     protected int wcaMinScrambleDistance = 2;
 
     /**


### PR DESCRIPTION
Based on a discussion about allowing 5x5 misscrambles, which pointed us back to https://github.com/thewca/tnoodle-lib/issues/17

Currently, this scrambles all layers that have centers using 3x3 random state scrambles from outside to inside, except for the innermost layer of even NxN, which resorts to using a 2x2 random state scramble. The model scales to any NxN automatically, meaning we can apply the concept to 6x6 and 7x7 on a whim.

As of the intial PR, the outermost layer (the "reduction stage") is *not* scrambled with a 3x3 random state, although this can be fixed by literally changing one character in the source code (changing a one to a zero in the constant `EXCLUDE_OUTER_LAYERS` definition)

Obviously this is not tested thoroughly because it's intended as a proof of concept at this stage. **These scrambles are not WCA-legal!** We also have not had a second pair of eyes to check the original mathematical analysis that prompted this approach.

Feel free to discuss!