### PR TITLE
Change Square-1 yellow to dark gray

### DIFF
--- a/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SquareOnePuzzle.java
+++ b/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SquareOnePuzzle.java
@@ -48,7 +48,7 @@ public class SquareOnePuzzle extends Puzzle {
         defaultColorScheme.put("F", Color.RED);
         defaultColorScheme.put("L", Color.BLUE);
         defaultColorScheme.put("R", Color.GREEN);
-        defaultColorScheme.put("U", Color.YELLOW);
+        defaultColorScheme.put("U", new Color(64, 64, 64));
     }
     @Override
     public Map<String, Color> getDefaultColorScheme() {


### PR DESCRIPTION
Changed Square-1 yellow to dark gray by adding a new color, this is the most common square-1 color scheme, and fixes the problem with yellow and white contrasting, this would make it easier to check scrambles, and also make it easier on our eyes. The community has already voiced support for this change. https://forum.worldcubeassociation.org/t/change-clock-and-square-1-color-scheme-on-tnoodle-scramble-pdfs-to-white-black/42647 

Obviously I know you can change it manually, but I think it would be good to change the default for the reasons above.

Before:
![image](https://github.com/thewca/tnoodle-lib/assets/48773372/41ac95da-91d4-4cae-8054-f7f9f3b39f8a)

After:
![image](https://github.com/thewca/tnoodle-lib/assets/48773372/74764afc-004c-405b-b1fd-0b4f308ee5d2)
