### PR TITLE
Actually use the Skewb Solver to solve Skewbs

### DIFF
--- a/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SkewbPuzzle.java
+++ b/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SkewbPuzzle.java
@@ -117,12 +117,25 @@ public class SkewbPuzzle extends Puzzle {
         private static final int SOLVER_D  = 5;
 
         // The order of faces in our internal `image` representation
-        private final int[] colorToSolver = new int[] {
+        private final int[] COLOR_TO_SOLVER = new int[] {
             SOLVER_U, SOLVER_BR, SOLVER_FR, SOLVER_D, SOLVER_FL, SOLVER_BL
         };
 
         // Primary base faces for both the Fixed and Free corners
         private final int[] CORNER_PRIMARY = { SOLVER_U, SOLVER_U, SOLVER_D, SOLVER_D };
+
+        private final String[][] ROTATION_LOOKUP = new String[][] {
+            { null, "", "R", "RR", null, null, null, null },
+            { "RLR", null, "RL", "RRLL", null, null, null, null },
+            { "LLRR", "LL", null, "LLR", null, null, null, null },
+            { "LR", "L", "LRR", null, null, null, null, null },
+            { null, null, null, null, null, "yyy", "Ry", "LLy" },
+            { null, null, null, null, "y", null, "RRyyy", "Lyyy" },
+            { null, null, null, null, "Ryyy", "RRy", null, "RLLy" },
+            { null, null, null, null, "LLyyy", "Ly", "RRLy", null },
+        };
+
+        private final int[] Z2 = new int[]{ 3, 5, 4, 0, 2, 1 };
 
         /**
          *           +---------+
@@ -150,9 +163,7 @@ public class SkewbPuzzle extends Puzzle {
         }
 
         SkewbState(int[][] _image) {
-            for (int i=0; i<6; i++) {
-                System.arraycopy(_image[i], 0, image[i], 0, 5);
-            }
+            deepCopy(_image, image);
         }
 
         private void turn(int axis, int pow, int[][] image) {
@@ -193,11 +204,62 @@ public class SkewbPuzzle extends Puzzle {
             }
         }
 
+        // in order to rotate the whole puzzle, we must touch two opposite corners.
+        // By definition, these two will not be in the same orbit, so only one of them
+        //   is defined as FCN notation in `swap`, and the other one references Jaap notation.
+        private void rotate(int axis, int pow, int[][] image) {
+            //axis:0-JaapR 1-JaapL 2-yAxis
+            for (int p=0; p<pow; p++) {
+                switch (axis) {
+                    case 0:
+                        // FCN L' move
+                        turn(2, 2, image);
+                        // Jaap R move
+                        swap(0, 0, 2, 0, 1, 0, image);
+                        swap(0, 4, 2, 2, 1, 1, image);
+                        swap(0, 3, 2, 4, 1, 2, image);
+                        swap(0, 2, 2, 1, 1, 3, image);
+                        swap(4, 2, 3, 2, 5, 1, image);
+                        break;
+                    case 1:
+                        // FCN R' move
+                        turn(0, 2, image);
+                        // Jaap L move
+                        swap(0, 0, 5, 0, 4, 0, image);
+                        swap(0, 1, 5, 2, 4, 1, image);
+                        swap(0, 3, 5, 1, 4, 3, image);
+                        swap(0, 2, 5, 4, 4, 2, image);
+                        swap(2, 1, 1, 2, 3, 3, image);
+                        break;
+                    case 2:
+                        // U and D faces
+                        swap(0, 1, 0, 3, 0, 4, 0, 2, image);
+                        swap(3, 1, 3, 2, 3, 4, 3, 3, image);
+                        // Four faces around the Skewb
+                        // Luckily, the sticker numbering is invariant under y rotations :)
+                        for (int s = 0; s < 5; s++) {
+                            swap(2, s, 1, s, 5,  s, 4, s, image);
+                        }
+                        break;
+                    default:
+                        assert false;
+                }
+            }
+        }
+
         private void swap(int f1, int s1, int f2, int s2, int f3, int s3, int[][] image) {
             int temp = image[f1][s1];
             image[f1][s1] = image[f2][s2];
             image[f2][s2] = image[f3][s3];
             image[f3][s3] = temp;
+        }
+
+        private void swap(int f1, int s1, int f2, int s2, int f3, int s3, int f4, int s4, int[][] image) {
+            int temp = image[f1][s1];
+            image[f1][s1] = image[f2][s2];
+            image[f2][s2] = image[f3][s3];
+            image[f3][s3] = image[f4][s4];
+            image[f4][s4] = temp;
         }
 
         /**
@@ -245,46 +307,98 @@ public class SkewbPuzzle extends Puzzle {
             return g;
         }
 
+        private int findCornerSlot(int c1, int c2, int c3, int[][] image) {
+            int[][] slots = new int[][] {
+                { image[0][4], image[1][1], image[2][2] },
+                { image[0][1], image[4][1], image[5][2] },
+                { image[3][1], image[4][4], image[2][3] },
+                { image[3][4], image[1][4], image[5][3] },
+                { image[0][3], image[2][1], image[4][2] },
+                { image[0][2], image[5][1], image[1][2] },
+                { image[3][2], image[2][4], image[1][3] },
+                { image[3][3], image[5][4], image[4][3] }
+            };
+
+            for (int i = 0; i < 8; i++) {
+                int s1 = slots[i][0], s2 = slots[i][1], s3 = slots[i][2];
+
+                // Check for each possible rotation
+                if ((s1 == c1 && s2 == c2 && s3 == c3) ||
+                    (s2 == c1 && s3 == c2 && s1 == c3) ||
+                    (s3 == c1 && s1 == c2 && s2 == c3)) {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
         public SkewbSolverState toSkewbSolverState() {
+            int[][] jaapImage = new int[6][5];
+
+            for(int f = 0; f < 6; f++) {
+                for(int s = 0; s < 5; s++) {
+                    // Initialize pretending that the scramble orientation is off by z2
+                    //   (the axis that runs along the plane between FCN-R and FCN-L)
+                    // This is required because the conversion from Jaap notation in the solver
+                    //   to WCA-FCN implicitly assumes a z2 rotation. But because z2 has order=2,
+                    //   it does not matter whether we do z2*scramble or scramble*z2.
+                    jaapImage[f][s] = Z2[this.image[f][s]];
+                }
+            }
+
+            // Jaap R corner piece is between faces U=0, BR=1, FR=2
+            int jaapR = findCornerSlot(0, 1, 2, jaapImage);
+
+            // Jaap L corner piece is between faces U=0, FL=4, BL=5
+            int jaapL = findCornerSlot(0, 4, 5, jaapImage);
+
+            String rotations = ROTATION_LOOKUP[jaapR][jaapL];
+
+            for (char face : rotations.toCharArray()) {
+                int axis = "RLy".indexOf(face);
+                rotate(axis, 1, jaapImage);
+            }
+
             SkewbSolverState state = new SkewbSolverState();
 
             int[] centers = new int[] {
-                colorToSolver[image[0][0]],
-                colorToSolver[image[2][0]],
-                colorToSolver[image[4][0]],
-                colorToSolver[image[1][0]],
-                colorToSolver[image[5][0]],
-                colorToSolver[image[3][0]]
+                COLOR_TO_SOLVER[jaapImage[0][0]],
+                COLOR_TO_SOLVER[jaapImage[2][0]],
+                COLOR_TO_SOLVER[jaapImage[4][0]],
+                COLOR_TO_SOLVER[jaapImage[1][0]],
+                COLOR_TO_SOLVER[jaapImage[5][0]],
+                COLOR_TO_SOLVER[jaapImage[3][0]]
             };
 
             int[][] fixedCorners = new int[][] {
-                { colorToSolver[image[0][4]], colorToSolver[image[1][1]], colorToSolver[image[2][2]] },
-                { colorToSolver[image[0][1]], colorToSolver[image[4][1]], colorToSolver[image[5][2]] },
-                { colorToSolver[image[3][1]], colorToSolver[image[4][4]], colorToSolver[image[2][3]] },
-                { colorToSolver[image[3][4]], colorToSolver[image[1][4]], colorToSolver[image[5][3]] }
+                { COLOR_TO_SOLVER[jaapImage[0][4]], COLOR_TO_SOLVER[jaapImage[1][1]], COLOR_TO_SOLVER[jaapImage[2][2]] },
+                { COLOR_TO_SOLVER[jaapImage[0][1]], COLOR_TO_SOLVER[jaapImage[4][1]], COLOR_TO_SOLVER[jaapImage[5][2]] },
+                { COLOR_TO_SOLVER[jaapImage[3][1]], COLOR_TO_SOLVER[jaapImage[4][4]], COLOR_TO_SOLVER[jaapImage[2][3]] },
+                { COLOR_TO_SOLVER[jaapImage[3][4]], COLOR_TO_SOLVER[jaapImage[1][4]], COLOR_TO_SOLVER[jaapImage[5][3]] }
             };
 
+            // To identify orientation, we turn the piece long enough until it matches
+            //   the corresponding center base color (because that's how the solver defines "oriented")
+            int[] fixedTwist = new int[4];
+            for (int i = 0; i < 4; i++) {
+                // We have rotated the puzzle so that by definition, the four fixed corners are permuted
+                int primaryColor = CORNER_PRIMARY[i];
+                while (fixedCorners[i][fixedTwist[i]] != primaryColor) {
+                    fixedTwist[i]++;
+                    assert fixedTwist[i] < 3;
+                }
+            }
+
             int[][] freeCorners = new int[][] {
-                { colorToSolver[image[0][3]], colorToSolver[image[2][1]], colorToSolver[image[4][2]] },
-                { colorToSolver[image[0][2]], colorToSolver[image[5][1]], colorToSolver[image[1][2]] },
-                { colorToSolver[image[3][2]], colorToSolver[image[2][4]], colorToSolver[image[1][3]] },
-                { colorToSolver[image[3][3]], colorToSolver[image[5][4]], colorToSolver[image[4][3]] }
+                { COLOR_TO_SOLVER[jaapImage[0][3]], COLOR_TO_SOLVER[jaapImage[2][1]], COLOR_TO_SOLVER[jaapImage[4][2]] },
+                { COLOR_TO_SOLVER[jaapImage[0][2]], COLOR_TO_SOLVER[jaapImage[5][1]], COLOR_TO_SOLVER[jaapImage[1][2]] },
+                { COLOR_TO_SOLVER[jaapImage[3][2]], COLOR_TO_SOLVER[jaapImage[2][4]], COLOR_TO_SOLVER[jaapImage[1][3]] },
+                { COLOR_TO_SOLVER[jaapImage[3][3]], COLOR_TO_SOLVER[jaapImage[5][4]], COLOR_TO_SOLVER[jaapImage[4][3]] }
             };
 
             // To identify corner permutations, we essentially use the same "sum trick" as PyraminxState:
             //   Every corner on the Skewb folds to a unique sum because the stickers on that corner never change
-            int[] currentFixedPerm = new int[4];
-            for (int i = 0; i < 4; i++) {
-                int sum = fixedCorners[i][0] + fixedCorners[i][1] + fixedCorners[i][2];
-                switch (sum) {
-                    case 4:  currentFixedPerm[i] = 0; break; // U-FR-BR (0+1+3)
-                    case 6:  currentFixedPerm[i] = 1; break; // U-FL-BL (0+2+4)
-                    case 8:  currentFixedPerm[i] = 2; break; // D-FL-FR (5+2+1)
-                    case 12: currentFixedPerm[i] = 3; break; // D-BL-BR (5+4+3)
-                    default: assert false;
-                }
-            }
-
             int[] currentFreePerm = new int[4];
             for (int i = 0; i < 4; i++) {
                 int sum = freeCorners[i][0] + freeCorners[i][1] + freeCorners[i][2];
@@ -294,17 +408,6 @@ public class SkewbPuzzle extends Puzzle {
                     case 9:  currentFreePerm[i] = 2; break;
                     case 11: currentFreePerm[i] = 3; break;
                     default: assert false;
-                }
-            }
-
-            // To identify orientation, we turn the piece long enough until it matches
-            //   the corresponding center base color (because that's how the solver defines "oriented")
-            int[] fixedTwist = new int[4];
-            for (int i = 0; i < 4; i++) {
-                int primaryColor = CORNER_PRIMARY[currentFixedPerm[i]];
-                while (fixedCorners[i][fixedTwist[i]] != primaryColor) {
-                    fixedTwist[i]++;
-                    assert fixedTwist[i] < 3;
                 }
             }
 

--- a/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SkewbPuzzle.java
+++ b/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SkewbPuzzle.java
@@ -121,21 +121,26 @@ public class SkewbPuzzle extends Puzzle {
             SOLVER_U, SOLVER_BR, SOLVER_FR, SOLVER_D, SOLVER_FL, SOLVER_BL
         };
 
-        // Primary base faces for both the Fixed and Free corners
-        private final int[] CORNER_PRIMARY = { SOLVER_U, SOLVER_U, SOLVER_D, SOLVER_D };
-
-        private final String[][] ROTATION_LOOKUP = new String[][] {
-            { null, "", "R", "RR", null, null, null, null },
-            { "RLR", null, "RL", "RRLL", null, null, null, null },
-            { "LLRR", "LL", null, "LLR", null, null, null, null },
-            { "LR", "L", "LRR", null, null, null, null, null },
-            { null, null, null, null, null, "yyy", "Ry", "LLy" },
-            { null, null, null, null, "y", null, "RRyyy", "Lyyy" },
-            { null, null, null, null, "Ryyy", "RRy", null, "RLLy" },
-            { null, null, null, null, "LLyyy", "Ly", "RRLy", null },
+        private final int[][] Z2_CORRECTIONS = new int[][]{
+            { 3, 5, 4, 0, 2, 1 },
+            { 2, 1, 3, 5, 4, 0 },
+            { 4, 0, 2, 1, 3, 5 },
         };
 
-        private final int[] Z2 = new int[]{ 3, 5, 4, 0, 2, 1 };
+        // Reusable coordinate maps for {Face, Sticker}
+        private final int[][][] FIXED_CORNER_COORDS = {
+            {{0, 4}, {1, 1}, {2, 2}}, // U-FR-BR
+            {{0, 1}, {4, 1}, {5, 2}}, // U-FL-BL
+            {{3, 1}, {4, 4}, {2, 3}}, // D-FL-FR
+            {{3, 4}, {1, 4}, {5, 3}}  // D-BL-BR
+        };
+
+        private final int[][][] FREE_CORNER_COORDS = {
+            {{0, 3}, {2, 1}, {4, 2}}, // U-FR-FL (Front)
+            {{0, 2}, {5, 1}, {1, 2}}, // U-BL-BR (Back)
+            {{3, 2}, {2, 4}, {1, 3}}, // D-FR-BR (Right-Down)
+            {{3, 3}, {5, 4}, {4, 3}}  // D-FL-BL (Left-Down)
+        };
 
         /**
          *           +---------+
@@ -204,62 +209,11 @@ public class SkewbPuzzle extends Puzzle {
             }
         }
 
-        // in order to rotate the whole puzzle, we must touch two opposite corners.
-        // By definition, these two will not be in the same orbit, so only one of them
-        //   is defined as FCN notation in `swap`, and the other one references Jaap notation.
-        private void rotate(int axis, int pow, int[][] image) {
-            //axis:0-JaapR 1-JaapL 2-yAxis
-            for (int p=0; p<pow; p++) {
-                switch (axis) {
-                    case 0:
-                        // FCN L' move
-                        turn(2, 2, image);
-                        // Jaap R move
-                        swap(0, 0, 2, 0, 1, 0, image);
-                        swap(0, 4, 2, 2, 1, 1, image);
-                        swap(0, 3, 2, 4, 1, 2, image);
-                        swap(0, 2, 2, 1, 1, 3, image);
-                        swap(4, 2, 3, 2, 5, 1, image);
-                        break;
-                    case 1:
-                        // FCN R' move
-                        turn(0, 2, image);
-                        // Jaap L move
-                        swap(0, 0, 5, 0, 4, 0, image);
-                        swap(0, 1, 5, 2, 4, 1, image);
-                        swap(0, 3, 5, 1, 4, 3, image);
-                        swap(0, 2, 5, 4, 4, 2, image);
-                        swap(2, 1, 1, 2, 3, 3, image);
-                        break;
-                    case 2:
-                        // U and D faces
-                        swap(0, 1, 0, 3, 0, 4, 0, 2, image);
-                        swap(3, 1, 3, 2, 3, 4, 3, 3, image);
-                        // Four faces around the Skewb
-                        // Luckily, the sticker numbering is invariant under y rotations :)
-                        for (int s = 0; s < 5; s++) {
-                            swap(2, s, 1, s, 5,  s, 4, s, image);
-                        }
-                        break;
-                    default:
-                        assert false;
-                }
-            }
-        }
-
         private void swap(int f1, int s1, int f2, int s2, int f3, int s3, int[][] image) {
             int temp = image[f1][s1];
             image[f1][s1] = image[f2][s2];
             image[f2][s2] = image[f3][s3];
             image[f3][s3] = temp;
-        }
-
-        private void swap(int f1, int s1, int f2, int s2, int f3, int s3, int f4, int s4, int[][] image) {
-            int temp = image[f1][s1];
-            image[f1][s1] = image[f2][s2];
-            image[f2][s2] = image[f3][s3];
-            image[f3][s3] = image[f4][s4];
-            image[f4][s4] = temp;
         }
 
         /**
@@ -307,60 +261,27 @@ public class SkewbPuzzle extends Puzzle {
             return g;
         }
 
-        private int findCornerSlot(int c1, int c2, int c3, int[][] image) {
-            int[][] slots = new int[][] {
-                { image[0][4], image[1][1], image[2][2] },
-                { image[0][1], image[4][1], image[5][2] },
-                { image[3][1], image[4][4], image[2][3] },
-                { image[3][4], image[1][4], image[5][3] },
-                { image[0][3], image[2][1], image[4][2] },
-                { image[0][2], image[5][1], image[1][2] },
-                { image[3][2], image[2][4], image[1][3] },
-                { image[3][3], image[5][4], image[4][3] }
-            };
-
-            for (int i = 0; i < 8; i++) {
-                int s1 = slots[i][0], s2 = slots[i][1], s3 = slots[i][2];
-
-                // Check for each possible rotation
-                if ((s1 == c1 && s2 == c2 && s3 == c3) ||
-                    (s2 == c1 && s3 == c2 && s1 == c3) ||
-                    (s3 == c1 && s1 == c2 && s2 == c3)) {
-                    return i;
-                }
-            }
-
-            return -1;
-        }
-
         public SkewbSolverState toSkewbSolverState() {
-            int[][] jaapImage = new int[6][5];
-
-            for(int f = 0; f < 6; f++) {
-                for(int s = 0; s < 5; s++) {
-                    // Initialize pretending that the scramble orientation is off by z2
-                    //   (the axis that runs along the plane between FCN-R and FCN-L)
-                    // This is required because the conversion from Jaap notation in the solver
-                    //   to WCA-FCN implicitly assumes a z2 rotation. But because z2 has order=2,
-                    //   it does not matter whether we do z2*scramble or scramble*z2.
-                    jaapImage[f][s] = Z2[this.image[f][s]];
+            int[] fcnTwist = new int[4];
+            for (int i = 0; i < 4; i++) {
+                while (this.image[FIXED_CORNER_COORDS[i][fcnTwist[i]][0]][FIXED_CORNER_COORDS[i][fcnTwist[i]][1]] != 0 &&
+                    this.image[FIXED_CORNER_COORDS[i][fcnTwist[i]][0]][FIXED_CORNER_COORDS[i][fcnTwist[i]][1]] != 3) {
+                    fcnTwist[i]++;
+                    assert fcnTwist[i] < 3;
                 }
             }
 
-            // Jaap R corner piece is between faces U=0, BR=1, FR=2
-            int jaapR = findCornerSlot(0, 1, 2, jaapImage);
+            int orientSum = fcnTwist[0] + fcnTwist[1] + fcnTwist[2] + fcnTwist[3];
+            int[] z2Correction = Z2_CORRECTIONS[orientSum % 3];
 
-            // Jaap L corner piece is between faces U=0, FL=4, BL=5
-            int jaapL = findCornerSlot(0, 4, 5, jaapImage);
-
-            String rotations = ROTATION_LOOKUP[jaapR][jaapL];
-
-            for (char face : rotations.toCharArray()) {
-                int axis = "RLy".indexOf(face);
-                rotate(axis, 1, jaapImage);
-            }
-
-            SkewbSolverState state = new SkewbSolverState();
+            int[][] jaapImage = new int[][] {
+                { z2Correction[image[3][0]], z2Correction[image[3][2]], z2Correction[image[3][4]], z2Correction[image[3][1]], z2Correction[image[3][3]] },
+                { z2Correction[image[5][0]], z2Correction[image[5][4]], z2Correction[image[5][3]], z2Correction[image[5][2]], z2Correction[image[5][1]] },
+                { z2Correction[image[4][0]], z2Correction[image[4][4]], z2Correction[image[4][3]], z2Correction[image[4][2]], z2Correction[image[4][1]] },
+                { z2Correction[image[0][0]], z2Correction[image[0][3]], z2Correction[image[0][1]], z2Correction[image[0][4]], z2Correction[image[0][2]] },
+                { z2Correction[image[2][0]], z2Correction[image[2][4]], z2Correction[image[2][3]], z2Correction[image[2][2]], z2Correction[image[2][1]] },
+                { z2Correction[image[1][0]], z2Correction[image[1][4]], z2Correction[image[1][3]], z2Correction[image[1][2]], z2Correction[image[1][1]] }
+            };
 
             int[] centers = new int[] {
                 COLOR_TO_SOLVER[jaapImage[0][0]],
@@ -371,37 +292,23 @@ public class SkewbPuzzle extends Puzzle {
                 COLOR_TO_SOLVER[jaapImage[3][0]]
             };
 
-            int[][] fixedCorners = new int[][] {
-                { COLOR_TO_SOLVER[jaapImage[0][4]], COLOR_TO_SOLVER[jaapImage[1][1]], COLOR_TO_SOLVER[jaapImage[2][2]] },
-                { COLOR_TO_SOLVER[jaapImage[0][1]], COLOR_TO_SOLVER[jaapImage[4][1]], COLOR_TO_SOLVER[jaapImage[5][2]] },
-                { COLOR_TO_SOLVER[jaapImage[3][1]], COLOR_TO_SOLVER[jaapImage[4][4]], COLOR_TO_SOLVER[jaapImage[2][3]] },
-                { COLOR_TO_SOLVER[jaapImage[3][4]], COLOR_TO_SOLVER[jaapImage[1][4]], COLOR_TO_SOLVER[jaapImage[5][3]] }
-            };
-
-            // To identify orientation, we turn the piece long enough until it matches
-            //   the corresponding center base color (because that's how the solver defines "oriented")
             int[] fixedTwist = new int[4];
             for (int i = 0; i < 4; i++) {
-                // We have rotated the puzzle so that by definition, the four fixed corners are permuted
-                int primaryColor = CORNER_PRIMARY[i];
-                while (fixedCorners[i][fixedTwist[i]] != primaryColor) {
+                while (COLOR_TO_SOLVER[jaapImage[FIXED_CORNER_COORDS[i][fixedTwist[i]][0]][FIXED_CORNER_COORDS[i][fixedTwist[i]][1]]] != SOLVER_U &&
+                    COLOR_TO_SOLVER[jaapImage[FIXED_CORNER_COORDS[i][fixedTwist[i]][0]][FIXED_CORNER_COORDS[i][fixedTwist[i]][1]]] != SOLVER_D) {
                     fixedTwist[i]++;
                     assert fixedTwist[i] < 3;
                 }
             }
 
-            int[][] freeCorners = new int[][] {
-                { COLOR_TO_SOLVER[jaapImage[0][3]], COLOR_TO_SOLVER[jaapImage[2][1]], COLOR_TO_SOLVER[jaapImage[4][2]] },
-                { COLOR_TO_SOLVER[jaapImage[0][2]], COLOR_TO_SOLVER[jaapImage[5][1]], COLOR_TO_SOLVER[jaapImage[1][2]] },
-                { COLOR_TO_SOLVER[jaapImage[3][2]], COLOR_TO_SOLVER[jaapImage[2][4]], COLOR_TO_SOLVER[jaapImage[1][3]] },
-                { COLOR_TO_SOLVER[jaapImage[3][3]], COLOR_TO_SOLVER[jaapImage[5][4]], COLOR_TO_SOLVER[jaapImage[4][3]] }
-            };
-
-            // To identify corner permutations, we essentially use the same "sum trick" as PyraminxState:
-            //   Every corner on the Skewb folds to a unique sum because the stickers on that corner never change
             int[] currentFreePerm = new int[4];
+            int[] freeTwist = new int[4];
             for (int i = 0; i < 4; i++) {
-                int sum = freeCorners[i][0] + freeCorners[i][1] + freeCorners[i][2];
+                int c0 = COLOR_TO_SOLVER[jaapImage[FREE_CORNER_COORDS[i][0][0]][FREE_CORNER_COORDS[i][0][1]]];
+                int c1 = COLOR_TO_SOLVER[jaapImage[FREE_CORNER_COORDS[i][1][0]][FREE_CORNER_COORDS[i][1][1]]];
+                int c2 = COLOR_TO_SOLVER[jaapImage[FREE_CORNER_COORDS[i][2][0]][FREE_CORNER_COORDS[i][2][1]]];
+
+                int sum = c0 + c1 + c2;
                 switch (sum) {
                     case 3:  currentFreePerm[i] = 0; break;
                     case 7:  currentFreePerm[i] = 1; break;
@@ -409,17 +316,15 @@ public class SkewbPuzzle extends Puzzle {
                     case 11: currentFreePerm[i] = 3; break;
                     default: assert false;
                 }
-            }
 
-            int[] freeTwist = new int[4];
-            for (int i = 0; i < 4; i++) {
-                int primaryColor = CORNER_PRIMARY[currentFreePerm[i]];
-                while (freeCorners[i][freeTwist[i]] != primaryColor) {
+                while (COLOR_TO_SOLVER[jaapImage[FREE_CORNER_COORDS[i][freeTwist[i]][0]][FREE_CORNER_COORDS[i][freeTwist[i]][1]]] != SOLVER_U &&
+                    COLOR_TO_SOLVER[jaapImage[FREE_CORNER_COORDS[i][freeTwist[i]][0]][FREE_CORNER_COORDS[i][freeTwist[i]][1]]] != SOLVER_D) {
                     freeTwist[i]++;
                     assert freeTwist[i] < 3;
                 }
             }
 
+            SkewbSolverState state = new SkewbSolverState();
             state.perm = SkewbSolver.packCenterPerm(centers) * SkewbSolver.FREE_CORNER_PERM + SkewbSolver.packCornerPerm(currentFreePerm);
             state.twst = SkewbSolver.packCornerOrient(freeTwist, fixedTwist);
 

--- a/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SkewbPuzzle.java
+++ b/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SkewbPuzzle.java
@@ -108,24 +108,16 @@ public class SkewbPuzzle extends Puzzle {
     }
 
     public class SkewbState extends PuzzleState {
-        // Jaap's notation used in the solver
-        private static final int SOLVER_U  = 0;
-        private static final int SOLVER_FR = 1;
-        private static final int SOLVER_FL = 2;
-        private static final int SOLVER_BR = 3;
-        private static final int SOLVER_BL = 4;
-        private static final int SOLVER_D  = 5;
+        private final int ORIENTATION_U = 0;
+        private final int ORIENTATION_D = 3;
 
-        // The order of faces in our internal `image` representation
-        private final int[] COLOR_TO_SOLVER = new int[] {
-            SOLVER_U, SOLVER_BR, SOLVER_FR, SOLVER_D, SOLVER_FL, SOLVER_BL
-        };
+        // This maps our solver's faces (index) to the face/sticker color
+        //   used in the Jaap solver (value)
+        private final int[] COLOR_TO_SOLVER = new int[] { 0, 3, 1, 5, 2, 4 };
 
-        private final int[][] Z2_CORRECTIONS = new int[][]{
-            { 3, 5, 4, 0, 2, 1 },
-            { 2, 1, 3, 5, 4, 0 },
-            { 4, 0, 2, 1, 3, 5 },
-        };
+        // This describes the changes to the internal `image` stickering schema
+        //   when performing a z2 rotation (the spatial axis right between the two corners facing you)
+        private final int[] Z2 = new int[] { 3, 5, 4, 0, 2, 1 };
 
         // Reusable coordinate maps for {Face, Sticker}
         private final int[][][] FIXED_CORNER_COORDS = {
@@ -141,6 +133,15 @@ public class SkewbPuzzle extends Puzzle {
             {{3, 2}, {2, 4}, {1, 3}}, // D-FR-BR (Right-Down)
             {{3, 3}, {5, 4}, {4, 3}}  // D-FL-BL (Left-Down)
         };
+
+        private final int[][] CENTER_COORDS = {
+            {0, 0}, {2, 0}, {4, 0}, {1, 0}, {5, 0}, {3, 0}
+        };
+
+        // The four corners in the FCN orbit (the Jaap "free" orbit) can be uniquely identified
+        //   by the sum of their stickers in the stickering schema of the internal solver.
+        //   So this array maps the sums (index) to the solver's permutation index.
+        private final int[] FREE_PERM_MAP = { -1, -1, -1, 0, -1, -1, -1, 1, -1, 2, -1, 3 };
 
         /**
          *           +---------+
@@ -216,6 +217,18 @@ public class SkewbPuzzle extends Puzzle {
             image[f3][s3] = temp;
         }
 
+        private void cycleSchemaCw(int[] stickeringSchema) {
+            // The six centers of a Skewb are always split in half (two groups of three)
+            //   separated by the plane parallel to the corner that you're turning
+            for (int i = 0; i < 2; i++) {
+                // Cycle one group of 3 separately
+                int temp = stickeringSchema[i];
+                stickeringSchema[i] = stickeringSchema[i + 4];
+                stickeringSchema[i + 4] = stickeringSchema[i + 2];
+                stickeringSchema[i + 2] = temp;
+            }
+        }
+
         /**
          * return a square skewb face. whose 4 corners are (-1, -1), (1, -1), (1, 1), (-1, 1). It will be transformed later.
          */
@@ -262,30 +275,39 @@ public class SkewbPuzzle extends Puzzle {
         }
 
         public SkewbSolverState toSkewbSolverState() {
-            // Look at the orientation of the four Jaap corners
+            // The internal solver is written in Jaap notation,
+            //   but WCA FCN and Jaap notation have misaligned reference frames:
+            // - In FCN, the "Holy Corner" (UFR) is fixed.
+            // - Jaap's solver relies on its four notation corners L, R, D and B to be fixed.
+            // The WCA FCN corner (UFR) is in the opposite orbit of the four Jaap corners,
+            //   and so are the FCN R, L and U corners as well.
+            // But the FCN B corner is in the "Jaap orbit", so because of that
+            //   the orientation of the four Jaap corners might be off if our scramble contained B moves.
             int[] fcnTwist = new int[4];
             for (int i = 0; i < 4; i++) {
-                while (this.image[FIXED_CORNER_COORDS[i][fcnTwist[i]][0]][FIXED_CORNER_COORDS[i][fcnTwist[i]][1]] != 0 &&
-                    this.image[FIXED_CORNER_COORDS[i][fcnTwist[i]][0]][FIXED_CORNER_COORDS[i][fcnTwist[i]][1]] != 3) {
+                int[][] coords = FIXED_CORNER_COORDS[i];
+                while (this.image[coords[fcnTwist[i]][0]][coords[fcnTwist[i]][1]] != ORIENTATION_U &&
+                    this.image[coords[fcnTwist[i]][0]][coords[fcnTwist[i]][1]] != ORIENTATION_D) {
                     fcnTwist[i]++;
                     assert fcnTwist[i] < 3;
                 }
             }
 
-            // FCN and Jaap notation have misaligned reference frames.
-            // In FCN, the "Holy Corner" (UFR) is fixed. Jaap's solver relies on the
-            // Opposite Orbit (the four corners it considers "fixed") to anchor orientation.
-            // Because FCN 'B' moves act on this Opposite Orbit, the sum of their twists modulo 3
-            // acts as a perfect mathematical ledger of the reference frame misalignment.
-            // We calculate this offset and apply the corresponding Z2_CORRECTION palette shift.
-            int orientSum = fcnTwist[0] + fcnTwist[1] + fcnTwist[2] + fcnTwist[3];
-            int[] z2Correction = Z2_CORRECTIONS[orientSum % 3];
+            // The most trivial way to "swap" the two orbits of corners on a Skewb is by performing z2.
+            // This is also what the internal solver does when converting between Jaap and FCN notation,
+            //   see SkewbSolver#getSolution for details.
+            int[] z2Correction = cloneArr(Z2);
 
-            // We must now physically rotate the puzzle by z2 (swapping U<->D, R<->B, F<->L).
-            // Why? The Jaap notation to WCA-FCN string converter implicitly assumes the puzzle
-            // is in this tilted reference frame. As a beautiful side effect, this rotation
-            // physically maps all four Jaap fixed corners into their required permutation slots,
-            // locking the absolute orientation for the solver.
+            // For every B move that was applied, the sum of orientations on that orbit will have shifted by 1 (mod 3).
+            // So we need to rotate our entire Skewb according to this shifted reference frame.
+            int orientSum = fcnTwist[0] + fcnTwist[1] + fcnTwist[2] + fcnTwist[3];
+            for (int i = 0; i < orientSum % 3; i++) {
+                // This implements a rotation along the diagonal through the FCN "holy corner" and FCN B.
+                cycleSchemaCw(z2Correction);
+            }
+
+            // Our B-move restickering contains an implicit z2 rotation, so instead of just applying it
+            //   to every element of `image`, we must also rotate our whole Skewb physically back by a z2.
             int[][] jaapImage = new int[][] {
                 { z2Correction[image[3][0]], z2Correction[image[3][2]], z2Correction[image[3][4]], z2Correction[image[3][1]], z2Correction[image[3][3]] },
                 { z2Correction[image[5][0]], z2Correction[image[5][4]], z2Correction[image[5][3]], z2Correction[image[5][2]], z2Correction[image[5][1]] },
@@ -295,19 +317,17 @@ public class SkewbPuzzle extends Puzzle {
                 { z2Correction[image[1][0]], z2Correction[image[1][4]], z2Correction[image[1][3]], z2Correction[image[1][2]], z2Correction[image[1][1]] }
             };
 
-            int[] centers = new int[] {
-                COLOR_TO_SOLVER[jaapImage[0][0]],
-                COLOR_TO_SOLVER[jaapImage[2][0]],
-                COLOR_TO_SOLVER[jaapImage[4][0]],
-                COLOR_TO_SOLVER[jaapImage[1][0]],
-                COLOR_TO_SOLVER[jaapImage[5][0]],
-                COLOR_TO_SOLVER[jaapImage[3][0]]
-            };
+            int[] centerPerm = new int[6];
+            for (int i = 0; i < 6; i++) {
+                int[] coords = CENTER_COORDS[i];
+                centerPerm[i] = COLOR_TO_SOLVER[jaapImage[coords[0]][coords[1]]];
+            }
 
             int[] fixedTwist = new int[4];
             for (int i = 0; i < 4; i++) {
-                while (COLOR_TO_SOLVER[jaapImage[FIXED_CORNER_COORDS[i][fixedTwist[i]][0]][FIXED_CORNER_COORDS[i][fixedTwist[i]][1]]] != SOLVER_U &&
-                    COLOR_TO_SOLVER[jaapImage[FIXED_CORNER_COORDS[i][fixedTwist[i]][0]][FIXED_CORNER_COORDS[i][fixedTwist[i]][1]]] != SOLVER_D) {
+                int[][] coords = FIXED_CORNER_COORDS[i];
+                while (jaapImage[coords[fixedTwist[i]][0]][coords[fixedTwist[i]][1]] != ORIENTATION_U &&
+                    jaapImage[coords[fixedTwist[i]][0]][coords[fixedTwist[i]][1]] != ORIENTATION_D) {
                     fixedTwist[i]++;
                     assert fixedTwist[i] < 3;
                 }
@@ -316,28 +336,24 @@ public class SkewbPuzzle extends Puzzle {
             int[] currentFreePerm = new int[4];
             int[] freeTwist = new int[4];
             for (int i = 0; i < 4; i++) {
-                int c0 = COLOR_TO_SOLVER[jaapImage[FREE_CORNER_COORDS[i][0][0]][FREE_CORNER_COORDS[i][0][1]]];
-                int c1 = COLOR_TO_SOLVER[jaapImage[FREE_CORNER_COORDS[i][1][0]][FREE_CORNER_COORDS[i][1][1]]];
-                int c2 = COLOR_TO_SOLVER[jaapImage[FREE_CORNER_COORDS[i][2][0]][FREE_CORNER_COORDS[i][2][1]]];
+                int[][] coords = FREE_CORNER_COORDS[i];
 
-                int sum = c0 + c1 + c2;
-                switch (sum) {
-                    case 3:  currentFreePerm[i] = 0; break; // Front (0+1+2)
-                    case 7:  currentFreePerm[i] = 1; break; // Back (0+4+3)
-                    case 9:  currentFreePerm[i] = 2; break; // Right-Down (5+1+3)
-                    case 11: currentFreePerm[i] = 3; break; // Left-Down (5+4+2)
-                    default: assert false;
-                }
+                int s0 = COLOR_TO_SOLVER[jaapImage[coords[0][0]][coords[0][1]]];
+                int s1 = COLOR_TO_SOLVER[jaapImage[coords[1][0]][coords[1][1]]];
+                int s2 = COLOR_TO_SOLVER[jaapImage[coords[2][0]][coords[2][1]]];
 
-                while (COLOR_TO_SOLVER[jaapImage[FREE_CORNER_COORDS[i][freeTwist[i]][0]][FREE_CORNER_COORDS[i][freeTwist[i]][1]]] != SOLVER_U &&
-                    COLOR_TO_SOLVER[jaapImage[FREE_CORNER_COORDS[i][freeTwist[i]][0]][FREE_CORNER_COORDS[i][freeTwist[i]][1]]] != SOLVER_D) {
+                currentFreePerm[i] = FREE_PERM_MAP[s0 + s1 + s2];
+                assert currentFreePerm[i] != -1;
+
+                while (jaapImage[coords[freeTwist[i]][0]][coords[freeTwist[i]][1]] != ORIENTATION_U &&
+                    jaapImage[coords[freeTwist[i]][0]][coords[freeTwist[i]][1]] != ORIENTATION_D) {
                     freeTwist[i]++;
                     assert freeTwist[i] < 3;
                 }
             }
 
             SkewbSolverState state = new SkewbSolverState();
-            state.perm = SkewbSolver.packCenterPerm(centers) * SkewbSolver.FREE_CORNER_PERM + SkewbSolver.packCornerPerm(currentFreePerm);
+            state.perm = SkewbSolver.packCenterPerm(centerPerm) * SkewbSolver.FREE_CORNER_PERM + SkewbSolver.packCornerPerm(currentFreePerm);
             state.twst = SkewbSolver.packCornerOrient(freeTwist, fixedTwist);
 
             return state;

--- a/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SkewbPuzzle.java
+++ b/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SkewbPuzzle.java
@@ -36,7 +36,7 @@ public class SkewbPuzzle extends Puzzle {
     @Override
     public PuzzleStateAndGenerator generateRandomMoves(Random r) {
         SkewbSolverState state = skewbSolver.randomState(r);
-        String scramble = skewbSolver.generateExactly(state, MIN_SCRAMBLE_LENGTH, r);
+        String scramble = skewbSolver.generateExactly(state, MIN_SCRAMBLE_LENGTH);
         assert scramble.split(" ").length == MIN_SCRAMBLE_LENGTH;
 
         PuzzleState pState;
@@ -325,7 +325,7 @@ public class SkewbPuzzle extends Puzzle {
 
         @Override
         public String solveIn(int n) {
-            return skewbSolver.solveIn(toSkewbSolverState(), n, new Random());
+            return skewbSolver.solveIn(toSkewbSolverState(), n);
         }
 
         @Override

--- a/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SkewbPuzzle.java
+++ b/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SkewbPuzzle.java
@@ -262,6 +262,7 @@ public class SkewbPuzzle extends Puzzle {
         }
 
         public SkewbSolverState toSkewbSolverState() {
+            // Look at the orientation of the four Jaap corners
             int[] fcnTwist = new int[4];
             for (int i = 0; i < 4; i++) {
                 while (this.image[FIXED_CORNER_COORDS[i][fcnTwist[i]][0]][FIXED_CORNER_COORDS[i][fcnTwist[i]][1]] != 0 &&
@@ -271,9 +272,20 @@ public class SkewbPuzzle extends Puzzle {
                 }
             }
 
+            // FCN and Jaap notation have misaligned reference frames.
+            // In FCN, the "Holy Corner" (UFR) is fixed. Jaap's solver relies on the
+            // Opposite Orbit (the four corners it considers "fixed") to anchor orientation.
+            // Because FCN 'B' moves act on this Opposite Orbit, the sum of their twists modulo 3
+            // acts as a perfect mathematical ledger of the reference frame misalignment.
+            // We calculate this offset and apply the corresponding Z2_CORRECTION palette shift.
             int orientSum = fcnTwist[0] + fcnTwist[1] + fcnTwist[2] + fcnTwist[3];
             int[] z2Correction = Z2_CORRECTIONS[orientSum % 3];
 
+            // We must now physically rotate the puzzle by z2 (swapping U<->D, R<->B, F<->L).
+            // Why? The Jaap notation to WCA-FCN string converter implicitly assumes the puzzle
+            // is in this tilted reference frame. As a beautiful side effect, this rotation
+            // physically maps all four Jaap fixed corners into their required permutation slots,
+            // locking the absolute orientation for the solver.
             int[][] jaapImage = new int[][] {
                 { z2Correction[image[3][0]], z2Correction[image[3][2]], z2Correction[image[3][4]], z2Correction[image[3][1]], z2Correction[image[3][3]] },
                 { z2Correction[image[5][0]], z2Correction[image[5][4]], z2Correction[image[5][3]], z2Correction[image[5][2]], z2Correction[image[5][1]] },
@@ -310,10 +322,10 @@ public class SkewbPuzzle extends Puzzle {
 
                 int sum = c0 + c1 + c2;
                 switch (sum) {
-                    case 3:  currentFreePerm[i] = 0; break;
-                    case 7:  currentFreePerm[i] = 1; break;
-                    case 9:  currentFreePerm[i] = 2; break;
-                    case 11: currentFreePerm[i] = 3; break;
+                    case 3:  currentFreePerm[i] = 0; break; // Front (0+1+2)
+                    case 7:  currentFreePerm[i] = 1; break; // Back (0+4+3)
+                    case 9:  currentFreePerm[i] = 2; break; // Right-Down (5+1+3)
+                    case 11: currentFreePerm[i] = 3; break; // Left-Down (5+4+2)
                     default: assert false;
                 }
 

--- a/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SkewbPuzzle.java
+++ b/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SkewbPuzzle.java
@@ -108,6 +108,21 @@ public class SkewbPuzzle extends Puzzle {
     }
 
     public class SkewbState extends PuzzleState {
+        // Jaap's notation used in the solver
+        private static final int SOLVER_U  = 0;
+        private static final int SOLVER_FR = 1;
+        private static final int SOLVER_FL = 2;
+        private static final int SOLVER_BR = 3;
+        private static final int SOLVER_BL = 4;
+        private static final int SOLVER_D  = 5;
+
+        // The order of faces in our internal `image` representation
+        private final int[] colorToSolver = new int[] {
+            SOLVER_U, SOLVER_BR, SOLVER_FR, SOLVER_D, SOLVER_FL, SOLVER_BL
+        };
+
+        // Primary base faces for both the Fixed and Free corners
+        private final int[] CORNER_PRIMARY = { SOLVER_U, SOLVER_U, SOLVER_D, SOLVER_D };
 
         /**
          *           +---------+
@@ -228,6 +243,89 @@ public class SkewbPuzzle extends Puzzle {
                 }
             }
             return g;
+        }
+
+        public SkewbSolverState toSkewbSolverState() {
+            SkewbSolverState state = new SkewbSolverState();
+
+            int[] centers = new int[] {
+                colorToSolver[image[0][0]],
+                colorToSolver[image[2][0]],
+                colorToSolver[image[4][0]],
+                colorToSolver[image[1][0]],
+                colorToSolver[image[5][0]],
+                colorToSolver[image[3][0]]
+            };
+
+            int[][] fixedCorners = new int[][] {
+                { colorToSolver[image[0][4]], colorToSolver[image[1][1]], colorToSolver[image[2][2]] },
+                { colorToSolver[image[0][1]], colorToSolver[image[4][1]], colorToSolver[image[5][2]] },
+                { colorToSolver[image[3][1]], colorToSolver[image[4][4]], colorToSolver[image[2][3]] },
+                { colorToSolver[image[3][4]], colorToSolver[image[1][4]], colorToSolver[image[5][3]] }
+            };
+
+            int[][] freeCorners = new int[][] {
+                { colorToSolver[image[0][3]], colorToSolver[image[2][1]], colorToSolver[image[4][2]] },
+                { colorToSolver[image[0][2]], colorToSolver[image[5][1]], colorToSolver[image[1][2]] },
+                { colorToSolver[image[3][2]], colorToSolver[image[2][4]], colorToSolver[image[1][3]] },
+                { colorToSolver[image[3][3]], colorToSolver[image[5][4]], colorToSolver[image[4][3]] }
+            };
+
+            // To identify corner permutations, we essentially use the same "sum trick" as PyraminxState:
+            //   Every corner on the Skewb folds to a unique sum because the stickers on that corner never change
+            int[] currentFixedPerm = new int[4];
+            for (int i = 0; i < 4; i++) {
+                int sum = fixedCorners[i][0] + fixedCorners[i][1] + fixedCorners[i][2];
+                switch (sum) {
+                    case 4:  currentFixedPerm[i] = 0; break; // U-FR-BR (0+1+3)
+                    case 6:  currentFixedPerm[i] = 1; break; // U-FL-BL (0+2+4)
+                    case 8:  currentFixedPerm[i] = 2; break; // D-FL-FR (5+2+1)
+                    case 12: currentFixedPerm[i] = 3; break; // D-BL-BR (5+4+3)
+                    default: assert false;
+                }
+            }
+
+            int[] currentFreePerm = new int[4];
+            for (int i = 0; i < 4; i++) {
+                int sum = freeCorners[i][0] + freeCorners[i][1] + freeCorners[i][2];
+                switch (sum) {
+                    case 3:  currentFreePerm[i] = 0; break;
+                    case 7:  currentFreePerm[i] = 1; break;
+                    case 9:  currentFreePerm[i] = 2; break;
+                    case 11: currentFreePerm[i] = 3; break;
+                    default: assert false;
+                }
+            }
+
+            // To identify orientation, we turn the piece long enough until it matches
+            //   the corresponding center base color (because that's how the solver defines "oriented")
+            int[] fixedTwist = new int[4];
+            for (int i = 0; i < 4; i++) {
+                int primaryColor = CORNER_PRIMARY[currentFixedPerm[i]];
+                while (fixedCorners[i][fixedTwist[i]] != primaryColor) {
+                    fixedTwist[i]++;
+                    assert fixedTwist[i] < 3;
+                }
+            }
+
+            int[] freeTwist = new int[4];
+            for (int i = 0; i < 4; i++) {
+                int primaryColor = CORNER_PRIMARY[currentFreePerm[i]];
+                while (freeCorners[i][freeTwist[i]] != primaryColor) {
+                    freeTwist[i]++;
+                    assert freeTwist[i] < 3;
+                }
+            }
+
+            state.perm = SkewbSolver.packCenterPerm(centers) * SkewbSolver.FREE_CORNER_PERM + SkewbSolver.packCornerPerm(currentFreePerm);
+            state.twst = SkewbSolver.packCornerOrient(freeTwist, fixedTwist);
+
+            return state;
+        }
+
+        @Override
+        public String solveIn(int n) {
+            return skewbSolver.solveIn(toSkewbSolverState(), n, new Random());
         }
 
         @Override

--- a/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SkewbSolver.java
+++ b/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SkewbSolver.java
@@ -7,13 +7,14 @@ public class SkewbSolver {
     private static final int N_MOVES = 4;
 
     private static final int[] fact = { 1, 1, 1, 3, 12, 60, 360 };//fact[x] = x!/2
-    private static char[][] permmv = new char[4320][4];
-    private static char[][] twstmv = new char[2187][4];
-    private static byte[] permprun = new byte[4320];
-    private static byte[] twstprun = new byte[2187];
-
-    private static final String[] move2str = { "R ", "R' ", "L ", "L' ", "D ",
-        "D' ", "B ", "B' " };
+    private static final int TWIST_ORIENTATIONS = 2187; // 3^7, orientation of last corner is implicitly defined
+    private static final int FREE_CORNER_PERM = fact[4];
+    private static final int CENTER_PERM = fact[6];
+    private static final int SKEWB_PERMUTATIONS = FREE_CORNER_PERM * CENTER_PERM;
+    private static char[][] permmv = new char[SKEWB_PERMUTATIONS][N_MOVES];
+    private static char[][] twstmv = new char[TWIST_ORIENTATIONS][N_MOVES];
+    private static byte[] permprun = new byte[SKEWB_PERMUTATIONS];
+    private static byte[] twstprun = new byte[TWIST_ORIENTATIONS];
 
     private static final int MAX_SOLUTION_LENGTH = 12;
 
@@ -28,8 +29,8 @@ public class SkewbSolver {
         2, 1, 0 };
 
     private static int getpermmv(int idx, int move) {
-        int centerindex = idx / 12;
-        int cornerindex = idx % 12;
+        int centerindex = idx / FREE_CORNER_PERM;
+        int cornerindex = idx % FREE_CORNER_PERM;
         int val = 0x543210;
         int parity = 0;
         int[] centerperm = new int[6];
@@ -71,14 +72,7 @@ public class SkewbSolver {
             centerperm[5] = centerperm[4];
             centerperm[4] = t;
         }
-        val = 0x543210;
-        for (int i = 0; i < 4; i++) {
-            int v = centerperm[i] << 2;
-            centerindex *= 6 - i;
-            centerindex += (val >> v) & 0xf;
-            val -= 0x111110L << v;
-        }
-        return centerindex * 12 + cornerpermmv[cornerindex][move];
+        return packCenterPerm(centerperm) * FREE_CORNER_PERM + cornerpermmv[cornerindex][move];
     }
 
     private static int gettwstmv(int idx, int move) {
@@ -122,25 +116,19 @@ public class SkewbSolver {
                 break;
             default:
         }
-        for (int i = 2; i >= 0; i--) {
-            idx = idx * 3 + twst[i] % 3;
-        }
-        for (int i = 3; i >= 0; i--) {
-            idx = idx * 3 + fixedtwst[i];
-        }
-        return idx;
+        return packCornerOrient(twst, fixedtwst);
     }
     static {
         init();
     }
     private static void init() {
-        for (int i = 0; i < 4320; i++) {
+        for (int i = 0; i < SKEWB_PERMUTATIONS; i++) {
             permprun[i] = -1;
             for (int j = 0; j < 4; j++) {
                 permmv[i][j] = (char) getpermmv(i, j);
             }
         }
-        for (int i = 0; i < 2187; i++) {
+        for (int i = 0; i < TWIST_ORIENTATIONS; i++) {
             twstprun[i] = -1;
             for (int j = 0; j < 4; j++) {
                 twstmv[i][j] = (char) gettwstmv(i, j);
@@ -148,7 +136,7 @@ public class SkewbSolver {
         }
         permprun[0] = 0;
         for (int l = 0; l < 6; l++) {
-            for (int p = 0; p < 4320; p++) {
+            for (int p = 0; p < SKEWB_PERMUTATIONS; p++) {
                 if (permprun[p] == l) {
                     for (int m = 0; m < 4; m++) {
                         int q = p;
@@ -164,7 +152,7 @@ public class SkewbSolver {
         }
         twstprun[0] = 0;
         for (int l = 0; l < 6; l++) {
-            for (int p = 0; p < 2187; p++) {
+            for (int p = 0; p < TWIST_ORIENTATIONS; p++) {
                 if (twstprun[p] == l) {
                     for (int m = 0; m < 4; m++) {
                         int q = p;
@@ -178,6 +166,55 @@ public class SkewbSolver {
                 }
             }
         }
+    }
+
+    /**
+     * Converts the list of centers into a number representing the (even) permutation of the edges.
+     * @param centers centers representation (permutation only)
+     * @return        an integer between 0 and 360 representing the (even) permutation of 6 elements
+     */
+    public static int packCenterPerm(int[] centers) {
+        int idx = 0;
+        int val = 0x543210;
+        for (int i = 0; i < 4; i++) {
+            int v = centers[i] << 2;
+            idx = (6 - i) * idx + ((val >> v) & 0xf);
+            val -= 0x111110 << v;
+        }
+        return idx;
+    }
+
+    /**
+     * Converts the list of free corners into a number representing the (even) permutation of the corners.
+     * @param freeCorners free corners representation (permutation only)
+     * @return            an integer between 0 and 12 representing the (even) permutation of 4 elements
+     */
+    public static int packCornerPerm(int[] freeCorners) {
+        int idx = 0;
+        int val = 0x3210;
+        for (int i = 0; i < 2; i++) {
+            int v = freeCorners[i] << 2;
+            idx = (4 - i) * idx + ((val >> v) & 0xf);
+            val -= 0x1110 << v;
+        }
+        return idx;
+    }
+
+    /**
+     * Converts the list of corners into a number representing the orientation of the corners.
+     * @param freeCorners    orientations for the free corners (the ones that actually swap places)
+     * @param fixedCorners   orientations for the fixed corners (the ones that only have orientation in FCN)
+     * @return               an integer between 0 and 2186 representing the orientation of 4 elements
+     */
+    public static int packCornerOrient(int[] freeCorners, int[] fixedCorners) {
+        int idx = 0;
+        for (int i = 2; i >= 0; i--) {
+            idx = idx * 3 + freeCorners[i] % 3;
+        }
+        for (int i = 3; i >= 0; i--) {
+            idx = idx * 3 + fixedCorners[i];
+        }
+        return idx;
     }
 
     protected int search(int depth, int perm, int twst, int maxl, int lm, int[] sol, Random randomizeMoves) {
@@ -221,9 +258,9 @@ public class SkewbSolver {
 
     public SkewbSolverState randomState(Random r) {
         SkewbSolverState state = new SkewbSolverState();
-        state.perm = r.nextInt(4320);
+        state.perm = r.nextInt(SKEWB_PERMUTATIONS);
         do {
-            state.twst = r.nextInt(2187);
+            state.twst = r.nextInt(TWIST_ORIENTATIONS);
         } while (!state.isSolvable());
         return state;
     }

--- a/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SkewbSolver.java
+++ b/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SkewbSolver.java
@@ -8,7 +8,7 @@ public class SkewbSolver {
 
     private static final int[] fact = { 1, 1, 1, 3, 12, 60, 360 };//fact[x] = x!/2
     private static final int TWIST_ORIENTATIONS = 2187; // 3^7, orientation of last corner is implicitly defined
-    private static final int FREE_CORNER_PERM = fact[4];
+    public static final int FREE_CORNER_PERM = fact[4];
     private static final int CENTER_PERM = fact[6];
     private static final int SKEWB_PERMUTATIONS = FREE_CORNER_PERM * CENTER_PERM;
     private static char[][] permmv = new char[SKEWB_PERMUTATIONS][N_MOVES];

--- a/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SkewbSolver.java
+++ b/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SkewbSolver.java
@@ -11,10 +11,10 @@ public class SkewbSolver {
     public static final int FREE_CORNER_PERM = fact[4];
     private static final int CENTER_PERM = fact[6];
     private static final int SKEWB_PERMUTATIONS = FREE_CORNER_PERM * CENTER_PERM;
-    private static char[][] permmv = new char[SKEWB_PERMUTATIONS][N_MOVES];
-    private static char[][] twstmv = new char[TWIST_ORIENTATIONS][N_MOVES];
-    private static byte[] permprun = new byte[SKEWB_PERMUTATIONS];
-    private static byte[] twstprun = new byte[TWIST_ORIENTATIONS];
+    private static final char[][] permmv = new char[SKEWB_PERMUTATIONS][N_MOVES];
+    private static final char[][] twstmv = new char[TWIST_ORIENTATIONS][N_MOVES];
+    private static final byte[] permprun = new byte[SKEWB_PERMUTATIONS];
+    private static final byte[] twstprun = new byte[TWIST_ORIENTATIONS];
 
     private static final int MAX_SOLUTION_LENGTH = 12;
 
@@ -265,24 +265,63 @@ public class SkewbSolver {
         return state;
     }
 
-    public String solveIn(SkewbSolverState state, int length, Random randomizeMoves) {
-        int[] sol = new int[MAX_SOLUTION_LENGTH];
-        int solutionLength = search(0, state.perm, state.twst, length, -1, sol, randomizeMoves);
-        if (solutionLength != -1) {
-            return getSolution(sol, solutionLength);
-        } else {
-            return null;
-        }
+    public String solveIn(SkewbSolverState state, int length) {
+        return solve(state, length, false, false);
     }
 
-    public String generateExactly(SkewbSolverState state, int length, Random randomizeMoves) {
+    public String generateExactly(SkewbSolverState state, int length) {
+        return solve(state, length, true, true);
+    }
+
+    private String solve(SkewbSolverState state, int desiredLength, boolean exactLength, boolean inverse) {
+        Random r = new Random();
         int[] sol = new int[MAX_SOLUTION_LENGTH];
-        int solutionLength = search(0, state.perm, state.twst, length, -1, sol, randomizeMoves);
-        if (solutionLength != -1) {
-            return getSolution(sol, solutionLength);
-        } else {
+
+        int solutionLength = -1;
+        int length = exactLength ? desiredLength : 0;
+
+        while (length <= desiredLength) {
+            solutionLength = search(0, state.perm, state.twst, length, -1, sol, r);
+
+            if (solutionLength != -1) {
+                break;
+            }
+
+            length++;
+        }
+
+        if (solutionLength == -1) {
             return null;
         }
+
+        if (solutionLength == 0) {
+            return "";
+        }
+
+        String fcnSolution = getSolution(sol, solutionLength);
+
+        if (inverse) {
+            String[] moves = fcnSolution.split(" ");
+            StringBuilder scramble = new StringBuilder(fcnSolution.length());
+
+            for (int i = moves.length - 1; i >= 0; i--) {
+                String move = moves[i];
+
+                // Skewb can only ever have 120 or -120 degree turns,
+                //   so this is an exhaustive either-or.
+                if (move.endsWith("'")) {
+                    scramble.append(move, 0, move.length() - 1);
+                } else {
+                    scramble.append(move).append("'");
+                }
+
+                scramble.append(" ");
+            }
+
+            return scramble.toString().trim();
+        }
+
+        return fcnSolution;
     }
 
     /**

--- a/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SkewbSolver.java
+++ b/scrambles/src/main/java/org/worldcubeassociation/tnoodle/puzzle/SkewbSolver.java
@@ -176,6 +176,8 @@ public class SkewbSolver {
     public static int packCenterPerm(int[] centers) {
         int idx = 0;
         int val = 0x543210;
+        // Stopping early (normally you would expect i < 5)
+        //   because the sixth element is implicitly defined by the first five
         for (int i = 0; i < 4; i++) {
             int v = centers[i] << 2;
             idx = (6 - i) * idx + ((val >> v) & 0xf);
@@ -192,6 +194,8 @@ public class SkewbSolver {
     public static int packCornerPerm(int[] freeCorners) {
         int idx = 0;
         int val = 0x3210;
+        // Stopping early (normally you would expect i < 3)
+        //   because the sixth element is implicitly defined by the first five
         for (int i = 0; i < 2; i++) {
             int v = freeCorners[i] << 2;
             idx = (4 - i) * idx + ((val >> v) & 0xf);


### PR DESCRIPTION
Turns out that for the past ~10 years, the fully-working Skewb solver implementation had only been used for generating a solution to the random state, but **not for checking whether that solution satisfies minimum WCA distance**.

In terms of code, the method `public PuzzleStateAndGenerator generateRandomMoves` correctly(-ish, see below) pointed to the optimized `SkewbSolver` but `public String solveIn` did NOT use the optimized solver and instead fell back to the `fringe`-based general-purpose solver of `Puzzle.java`.

This PR attempts to fix up this glaring oversight, by more-or-less playing copycat and stealing from `PyraminxPuzzle` and `PyraminxSolver`. Remarks about the individual code snippets are added inline.

In the process, I have discovered an interesting bug: The initial solution that was found to the random state of `generateExactly` was never inverted! For years and years, the WCA scramble sheets of Skewb have printed the exact opposite (literally, in terms of the inverse operation) of what they were supposed to print. Luckily, this did not affect correctness of the scrambles but it's curious nonetheless.

Particular observation points for this PR:
- I have added Iterative Deepening to the solver, to allow `solveIn` to return early if it finds a shorter solution. The implementation is stolen and adapted from `PyraminxSolver`, is it correct?
- The mapping from `SkewbPuzzle`'s internal `SkewbState` to the solver's `SkewbSolverState` has been created manually and cross-checked by an LLM. My trust in LLMs for this kind of task is quite low however, so I definitely need at least one human pair of eyes to cross-check
- The "inverse scramble" implementation is pretty crude, are there better/smarter ways?